### PR TITLE
Upgrade Aspire dependencies to 13.1.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,24 +5,24 @@
   </PropertyGroup>
 
   <ItemGroup Label="Production">
-    <PackageVersion Include="Aspire.Hosting" Version="9.3.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.3.0" />
-    <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="9.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.2" />
+    <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test-only">
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.100",
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "allowPrerelease": false
   }
 }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -86,9 +86,10 @@ public class AddDocumentDBTests
         var connectionStringResource = dbResource as IResourceWithConnectionString;
         Assert.NotNull(connectionStringResource);
         var connectionString = await connectionStringResource.GetConnectionStringAsync();
-        Assert.Equal($"mongodb://admin:{dbResource.Parent.PasswordParameter?.Value}@localhost:10260?authSource=admin&authMechanism=SCRAM-SHA-256", await serverResource.GetConnectionStringAsync());
+        var passwordValue = await dbResource.Parent.PasswordParameter!.GetValueAsync(default);
+        Assert.Equal($"mongodb://admin:{passwordValue}@localhost:10260?authSource=admin&authMechanism=SCRAM-SHA-256", await serverResource.GetConnectionStringAsync());
         Assert.Equal("mongodb://admin:{DocumentDB-password.value}@{DocumentDB.bindings.tcp.host}:{DocumentDB.bindings.tcp.port}?authSource=admin&authMechanism=SCRAM-SHA-256", serverResource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal($"mongodb://admin:{dbResource.Parent.PasswordParameter?.Value}@localhost:10260/mydatabase?authSource=admin&authMechanism=SCRAM-SHA-256", connectionString);
+        Assert.Equal($"mongodb://admin:{passwordValue}@localhost:10260/mydatabase?authSource=admin&authMechanism=SCRAM-SHA-256", connectionString);
         Assert.Equal("mongodb://admin:{DocumentDB-password.value}@{DocumentDB.bindings.tcp.host}:{DocumentDB.bindings.tcp.port}/mydatabase?authSource=admin&authMechanism=SCRAM-SHA-256", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 


### PR DESCRIPTION
## Summary

Upgrade all Aspire packages from 9.3.0 to 13.1.2 and align transitive dependencies.

## Changes

### Aspire packages (9.3.0 → 13.1.2)
- `Aspire.Hosting`
- `Aspire.Hosting.AppHost`
- `Aspire.Hosting.Testing`
- `Aspire.MongoDB.Driver`

### Aligned transitive dependencies
| Package | From | To |
|---|---|---|
| AspNetCore.HealthChecks.MongoDb | 8.1.0 | 9.0.0 |
| Microsoft.Extensions.Configuration.Binder | 9.0.4 | 9.0.11 |
| Microsoft.Extensions.Diagnostics.HealthChecks | 9.0.4 | 9.0.11 |
| Microsoft.Extensions.Hosting | 9.0.4 | 9.0.11 |
| Microsoft.Extensions.Hosting.Abstractions | 9.0.4 | 9.0.11 |
| MongoDB.Driver | 3.0.0 | 3.5.0 |
| OpenTelemetry.Extensions.Hosting | 1.9.0 | 1.14.0 |

### Breaking API fix
- `ParameterResource.Value` is obsolete in Aspire 13.x — updated test code to use `GetValueAsync`

### Other
- Updated `global.json` rollForward policy to `latestMajor` for broader SDK compatibility
