### PR TITLE
Add NuGet package metadata and publish workflow

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,46 @@
+name: Publish NuGet Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore
+        run: dotnet restore azure-databases-aspire.sln
+
+      - name: Build
+        run: dotnet build azure-databases-aspire.sln -c Release --no-restore
+
+      - name: Test
+        run: dotnet test azure-databases-aspire.sln -c Release --no-build
+
+      - name: Pack
+        run: dotnet pack src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj -c Release --no-build -o ./artifacts
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package
+          path: ./artifacts/*.nupkg
+
+      - name: Push to NuGet
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          global-json-file: global.json
 
       - name: Restore
         run: dotnet restore azure-databases-aspire.sln

--- a/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
+++ b/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
@@ -3,11 +3,23 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting DocumentDB</PackageTags>
-    <PackageIconFullPath>$(SharedDir)AzureCosmosDB_256x.png</PackageIconFullPath>
-    <Description>DocumentDB support for .NET Aspire.</Description>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
+
+  <!-- NuGet package metadata -->
+  <PropertyGroup>
+    <Description>DocumentDB support for .NET Aspire. Provides extension methods and resource definitions for a .NET Aspire AppHost to configure a DocumentDB resource.</Description>
+    <Authors>Microsoft</Authors>
+    <Copyright>Copyright (c) Microsoft 2025</Copyright>
+    <PackageTags>aspire integration hosting documentdb mongodb cosmosdb azure database</PackageTags>
+    <PackageProjectUrl>https://github.com/microsoft/azure-databases-aspire</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/microsoft/azure-databases-aspire</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>AzureCosmosDB_256x.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,10 +31,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" />
+    <None Include="$(SharedDir)AzureCosmosDB_256x.png" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" />
+    <PackageReference Include="MinVer" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Add proper NuGet metadata per [best practices](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices): authors, MIT license, icon, README, repository URL, tags
- Replace non-functional `PackageIconFullPath` with correct `PackageIcon` + packed file
- Wire up MinVer for git-tag-based SemVer versioning (`v*` tag prefix)
- Add GitHub Actions workflow for NuGet publishing:
  - Triggers on `v*` tag push and manual `workflow_dispatch`
  - Builds, tests, packs, and uploads artifact
  - Pushes to nuget.org only on tag push (requires `NUGET_API_KEY` repository secret)
  - Uses `--skip-duplicate` for safe reruns

## Setup required

Add a `NUGET_API_KEY` repository secret with a nuget.org API key scoped to the package owner organization.

## How to publish

```bash
git tag v0.1.0
git push origin v0.1.0
```

## Tested

- Workflow tested via workflow_dispatch on fork: build, test, pack all pass
- Package contents verified: icon, README, license, and metadata all included in .nupkg