### PR TITLE
Add configuration APIs for log level, data seeding, TLS, and telemetry

### DIFF
--- a/azure-databases-aspire.sln
+++ b/azure-databases-aspire.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground", "playground\Pl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.EndToEndApp", "tests\Aspire.Hosting.DocumentDB.EndToEndApp\Aspire.Hosting.DocumentDB.EndToEndApp.csproj", "{6D820CCE-164F-4337-9EA8-BF0126F54903}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp", "tests\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj", "{2B536A64-0391-4DEE-8C75-F47756A7CD8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -89,6 +91,18 @@ Global
 		{6D820CCE-164F-4337-9EA8-BF0126F54903}.Release|x64.Build.0 = Release|Any CPU
 		{6D820CCE-164F-4337-9EA8-BF0126F54903}.Release|x86.ActiveCfg = Release|Any CPU
 		{6D820CCE-164F-4337-9EA8-BF0126F54903}.Release|x86.Build.0 = Release|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Release|x64.Build.0 = Release|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -98,6 +112,7 @@ Global
 		{1E84BF6C-20BF-1AE3-2A18-16A50CA372DC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C3BD54DB-3743-402A-AB8B-36A329F8B293} = {12E5C810-18C6-BE57-4EA6-3F3BE821652E}
 		{6D820CCE-164F-4337-9EA8-BF0126F54903} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{2B536A64-0391-4DEE-8C75-F47756A7CD8E} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {78348A45-51DE-49D0-BB37-692D46DC6154}

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -25,6 +25,7 @@ public static class DocumentDBBuilderExtensions
     private const string EnableTelemetryEnvVarName = "ENABLE_TELEMETRY";
     private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
     private const string OwnerEnvVarName = "OWNER";
+    private const string DataPathEnvVarName = "DATA_PATH";
 
     private const string DataPath = "/home/documentdb/postgresql/data";
     private const string InitDataPath = "/init_doc_db.d";
@@ -173,7 +174,7 @@ public static class DocumentDBBuilderExtensions
             .WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), targetPath, isReadOnly)
             .WithEnvironment(context =>
             {
-                context.EnvironmentVariables["DATA_PATH"] = targetPath;
+                context.EnvironmentVariables[DataPathEnvVarName] = targetPath;
             });
     }
 
@@ -193,7 +194,7 @@ public static class DocumentDBBuilderExtensions
             .WithBindMount(source, DataPath, isReadOnly)
             .WithEnvironment(context =>
             {
-                context.EnvironmentVariables["DATA_PATH"] = DataPath;
+                context.EnvironmentVariables[DataPathEnvVarName] = DataPath;
             });
     }
 

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -15,9 +15,19 @@ public static class DocumentDBBuilderExtensions
 {
     // default internal port is 10260.
     private const int DefaultContainerPort = 10260;
-
     private const string UserEnvVarName = "USERNAME";
     private const string PasswordEnvVarName = "PASSWORD";
+    private const string LogLevelEnvVarName = "LOG_LEVEL";
+    private const string InitDataPathEnvVarName = "INIT_DATA_PATH";
+    private const string SkipInitDataEnvVarName = "SKIP_INIT_DATA";
+    private const string CertPathEnvVarName = "CERT_PATH";
+    private const string KeyFileEnvVarName = "KEY_FILE";
+    private const string EnableTelemetryEnvVarName = "ENABLE_TELEMETRY";
+    private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
+    private const string OwnerEnvVarName = "OWNER";
+
+    private const string DataPath = "/home/documentdb/postgresql/data";
+    private const string InitDataPath = "/init_doc_db.d";
 
     /// <summary>
     /// Adds a DocumentDB resource to the application model. A container is used for local development.
@@ -157,7 +167,7 @@ public static class DocumentDBBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        targetPath ??= "/home/documentdb/postgresql/data";
+        targetPath ??= DataPath;
 
         return builder
             .WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), targetPath, isReadOnly)
@@ -179,14 +189,137 @@ public static class DocumentDBBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        const string targetPath = "/home/documentdb/postgresql/data";
-
         return builder
-            .WithBindMount(source, targetPath, isReadOnly)
+            .WithBindMount(source, DataPath, isReadOnly)
             .WithEnvironment(context =>
             {
-                context.EnvironmentVariables["DATA_PATH"] = targetPath;
+                context.EnvironmentVariables["DATA_PATH"] = DataPath;
             });
+    }
+
+    /// <summary>
+    /// Configures the DocumentDB Local container log level.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="logLevel">The log level to configure.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithLogLevel(this IResourceBuilder<DocumentDBServerResource> builder, DocumentDBLogLevel logLevel)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[LogLevelEnvVarName] = logLevel.ToEnvironmentValue();
+        });
+    }
+
+    /// <summary>
+    /// Mounts custom initialization scripts into the DocumentDB Local container.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="source">The source directory on the host to mount into the container.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithInitData(this IResourceBuilder<DocumentDBServerResource> builder, string source)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        return builder
+            .WithBindMount(source, InitDataPath, isReadOnly: true)
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables[InitDataPathEnvVarName] = InitDataPath;
+                context.EnvironmentVariables[SkipInitDataEnvVarName] = "true";
+            });
+    }
+
+    /// <summary>
+    /// Disables the built-in sample data initialization performed by the DocumentDB Local container.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithoutSampleData(this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[SkipInitDataEnvVarName] = "true";
+        });
+    }
+
+    /// <summary>
+    /// Mounts a custom TLS certificate and key into the DocumentDB Local container.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="certPath">The certificate file to mount into the container.</param>
+    /// <param name="keyPath">The private key file to mount into the container.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithTlsCertificate(this IResourceBuilder<DocumentDBServerResource> builder, string certPath, string keyPath)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(certPath);
+        ArgumentException.ThrowIfNullOrEmpty(keyPath);
+
+        var certTargetPath = GetMountedFilePath(certPath, nameof(certPath), "documentdb-cert-");
+        var keyTargetPath = GetMountedFilePath(keyPath, nameof(keyPath), "documentdb-key-");
+
+        return builder
+            .WithBindMount(certPath, certTargetPath, isReadOnly: true)
+            .WithBindMount(keyPath, keyTargetPath, isReadOnly: true)
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables[CertPathEnvVarName] = certTargetPath;
+                context.EnvironmentVariables[KeyFileEnvVarName] = keyTargetPath;
+            });
+    }
+
+    /// <summary>
+    /// Enables or disables DocumentDB Local telemetry.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="enabled">Whether telemetry should be enabled.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithTelemetry(this IResourceBuilder<DocumentDBServerResource> builder, bool enabled = true)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[EnableTelemetryEnvVarName] = enabled ? "true" : "false";
+        });
+    }
+
+    /// <summary>
+    /// Disables the DocumentDB Local extended RUM index support.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithoutExtendedRum(this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[DisableExtendedRumEnvVarName] = "true";
+        });
+    }
+
+    /// <summary>
+    /// Configures the owner used by the DocumentDB Local container.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="owner">The owner value to configure.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithOwner(this IResourceBuilder<DocumentDBServerResource> builder, string owner)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(owner);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[OwnerEnvVarName] = owner;
+        });
     }
 
     /// <summary>
@@ -220,5 +353,17 @@ public static class DocumentDBBuilderExtensions
 
         builder.Resource.SetAllowInsecureTls(allowInsecureTls);
         return builder;
+    }
+
+    private static string GetMountedFilePath(string source, string paramName, string prefix)
+    {
+        var fileName = Path.GetFileName(source);
+
+        if (string.IsNullOrEmpty(fileName))
+        {
+            throw new ArgumentException("The path must include a file name.", paramName);
+        }
+
+        return $"/{prefix}{fileName}";
     }
 }

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBLogLevel.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBLogLevel.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Represents the supported DocumentDB Local container log levels.
+/// </summary>
+public enum DocumentDBLogLevel
+{
+    Quiet,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace
+}
+
+internal static class DocumentDBLogLevelExtensions
+{
+    public static string ToEnvironmentValue(this DocumentDBLogLevel logLevel) => logLevel switch
+    {
+        DocumentDBLogLevel.Quiet => "quiet",
+        DocumentDBLogLevel.Error => "error",
+        DocumentDBLogLevel.Warn => "warn",
+        DocumentDBLogLevel.Info => "info",
+        DocumentDBLogLevel.Debug => "debug",
+        DocumentDBLogLevel.Trace => "trace",
+        _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, "Unsupported DocumentDB log level.")
+    };
+}

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -25,6 +25,31 @@ var myService = builder.AddProject<Projects.MyService>()
 
 For local development, the generated DocumentDB connection strings enable TLS and allow the self-signed local certificate automatically so client applications can connect without extra manual connection string settings.
 
+## Additional container configuration
+
+The hosting integration also exposes several DocumentDB Local container options for debugging, seeding, and closer-to-production local setups:
+
+```csharp
+var documentdb = builder.AddDocumentDB("documentdb")
+    .WithLogLevel(DocumentDBLogLevel.Debug)
+    .WithInitData("../seed")
+    .WithTlsCertificate("../certs/documentdb.pem", "../certs/documentdb.key")
+    .WithTelemetry(enabled: false)
+    .WithoutExtendedRum()
+    .WithOwner("documentdb");
+
+var db = documentdb.AddDatabase("mydb");
+```
+
+Use `WithoutSampleData()` when you want to disable the built-in sample collections without mounting custom initialization scripts:
+
+```csharp
+var documentdb = builder.AddDocumentDB("documentdb")
+    .WithoutSampleData();
+```
+
+`WithInitData(...)` mounts a host directory into `/init_doc_db.d` and also disables the built-in sample data so your custom scripts are the only initialization source.
+
 ## Connecting from client applications
 
 To connect to DocumentDB from your application services, you'll need to install the MongoDB client integration package:

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -1,5 +1,15 @@
 namespace Aspire.Hosting
 {
+    public enum DocumentDBLogLevel
+    {
+        Quiet = 0,
+        Error = 1,
+        Warn = 2,
+        Info = 3,
+        Debug = 4,
+        Trace = 5,
+    }
+
     public static partial class DocumentDBBuilderExtensions
     {
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBDatabaseResource> AddDatabase(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string name, string? databaseName = null) { throw null; }
@@ -8,9 +18,23 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> AddDocumentDB(this IDistributedApplicationBuilder builder, string name, int? port) { throw null; }
 
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithLogLevel(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, DocumentDBLogLevel logLevel) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithInitData(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string source) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutSampleData(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTlsCertificate(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string certPath, string keyPath) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTelemetry(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool enabled = true) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutExtendedRum(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithOwner(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string owner) { throw null; }
+
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataBindMount(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string source, bool isReadOnly = false) { throw null; }
 
-        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataVolume(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string? name = null, bool isReadOnly = false) { throw null; }
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataVolume(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string? name = null, bool isReadOnly = false, string? targetPath = null) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> UseTls(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool useTls = true) { throw null; }
 
@@ -34,11 +58,13 @@ namespace Aspire.Hosting.ApplicationModel
 
     public partial class DocumentDBServerResource : ContainerResource, IResourceWithConnectionString, IResource, IManifestExpressionProvider, IValueProvider, IValueWithReferences
     {
+        public DocumentDBServerResource(string name) : base(default!, default) { }
+
         public DocumentDBServerResource(string name, ParameterResource? userNameParameter, ParameterResource? passwordParameter) : base(default!, default) { }
 
         public ReferenceExpression ConnectionStringExpression { get { throw null; } }
 
-    public System.Collections.Generic.IReadOnlyList<ApplicationModel.DocumentDBDatabaseResource> Databases { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<ApplicationModel.DocumentDBDatabaseResource> Databases { get { throw null; } }
 
         public ParameterResource? PasswordParameter { get { throw null; } }
 

--- a/tests/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.DocumentDB\Aspire.Hosting.DocumentDB.csproj" IsAspireProjectResource="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp/Program.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Aspire.Hosting;
+
+namespace Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+        var assets = TestAssets.Create();
+
+        builder.AddDocumentDB("documentdb")
+            .WithLogLevel(DocumentDBLogLevel.Debug)
+            .WithInitData(assets.InitDataPath)
+            .WithTlsCertificate(assets.CertificatePath, assets.KeyPath)
+            .WithTelemetry(enabled: false)
+            .WithoutSampleData()
+            .WithoutExtendedRum()
+            .WithOwner("documentdb")
+            .AddDatabase("appdb");
+
+        var app = builder.Build();
+
+        await app.RunAsync();
+    }
+
+    private sealed record TestAssets(string RootPath, string InitDataPath, string CertificatePath, string KeyPath)
+    {
+        public static TestAssets Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), nameof(Aspire), nameof(Hosting), "DocumentDBConfiguredEndToEnd", Guid.NewGuid().ToString("N"));
+            var initDataPath = Path.Combine(rootPath, "init");
+            var certificatePath = Path.Combine(rootPath, "documentdb.pem");
+            var keyPath = Path.Combine(rootPath, "documentdb.key");
+
+            Directory.CreateDirectory(initDataPath);
+            File.WriteAllText(Path.Combine(initDataPath, "01-seed.js"), """
+                db = db.getSiblingDB("appdb");
+                db.widgets.insertOne({ _id: "seeded-widget", source: "custom-init" });
+                """);
+
+            WriteCertificateFiles(certificatePath, keyPath);
+
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => TryDeleteDirectory(rootPath);
+
+            return new TestAssets(rootPath, initDataPath, certificatePath, keyPath);
+        }
+
+        private static void WriteCertificateFiles(string certificatePath, string keyPath)
+        {
+            using var rsa = RSA.Create(2048);
+
+            var request = new CertificateRequest("CN=Aspire.Hosting.DocumentDB.E2E", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, false));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+            var subjectAlternativeNames = new SubjectAlternativeNameBuilder();
+            subjectAlternativeNames.AddDnsName("localhost");
+            subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+            subjectAlternativeNames.AddIpAddress(IPAddress.IPv6Loopback);
+            request.CertificateExtensions.Add(subjectAlternativeNames.Build());
+
+            using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7));
+
+            File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
+            File.WriteAllText(keyPath, rsa.ExportPkcs8PrivateKeyPem());
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(path, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/tests/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp/Program.cs
@@ -84,8 +84,9 @@ public class Program
             {
                 Directory.Delete(path, recursive: true);
             }
-            catch
+            catch (Exception ex)
             {
+                Console.Error.WriteLine($"Failed to delete temporary directory '{path}': {ex.Message}");
             }
         }
     }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Aspire.Hosting.DocumentDB.Tests;
@@ -190,5 +191,223 @@ public class AddDocumentDBTests
 
         Assert.Equal("mongodb://admin:{DocumentDB1-password.value}@{DocumentDB1.bindings.tcp.host}:{DocumentDB1.bindings.tcp.port}/imports?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true", db1.Resource.ConnectionStringExpression.ValueExpression);
         Assert.Equal("mongodb://admin:{DocumentDB2-password.value}@{DocumentDB2.bindings.tcp.host}:{DocumentDB2.bindings.tcp.port}/imports?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true", db2.Resource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Theory]
+    [InlineData(DocumentDBLogLevel.Quiet, "quiet")]
+    [InlineData(DocumentDBLogLevel.Error, "error")]
+    [InlineData(DocumentDBLogLevel.Warn, "warn")]
+    [InlineData(DocumentDBLogLevel.Info, "info")]
+    [InlineData(DocumentDBLogLevel.Debug, "debug")]
+    [InlineData(DocumentDBLogLevel.Trace, "trace")]
+    public async Task WithLogLevelAddsEnvironmentVariable(DocumentDBLogLevel logLevel, string expectedValue)
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithLogLevel(logLevel);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+
+        Assert.Equal(expectedValue, env["LOG_LEVEL"]);
+    }
+
+    [Fact]
+    public async Task WithInitDataAddsReadOnlyBindMountAndDisablesSampleData()
+    {
+        var source = Path.GetFullPath(Path.Combine("TestData", "init"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithInitData(source);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        Assert.True(containerResource.TryGetContainerMounts(out var mounts));
+        var mount = Assert.Single(mounts);
+        Assert.Equal(source, mount.Source);
+        Assert.Equal("/init_doc_db.d", mount.Target);
+        Assert.Equal(ContainerMountType.BindMount, mount.Type);
+        Assert.True(mount.IsReadOnly);
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("/init_doc_db.d", env["INIT_DATA_PATH"]);
+        Assert.Equal("true", env["SKIP_INIT_DATA"]);
+    }
+
+    [Fact]
+    public async Task WithoutSampleDataAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithoutSampleData();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["SKIP_INIT_DATA"]);
+    }
+
+    [Fact]
+    public async Task WithTlsCertificateAddsReadOnlyBindMountsAndEnvironmentVariables()
+    {
+        var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.pem"));
+        var keyPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.key"));
+        var expectedCertTarget = $"/documentdb-cert-{Path.GetFileName(certPath)}";
+        var expectedKeyTarget = $"/documentdb-key-{Path.GetFileName(keyPath)}";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTlsCertificate(certPath, keyPath);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        Assert.True(containerResource.TryGetContainerMounts(out var mounts));
+        var certMount = Assert.Single(mounts, mount => mount.Source == certPath);
+        Assert.Equal(expectedCertTarget, certMount.Target);
+        Assert.Equal(ContainerMountType.BindMount, certMount.Type);
+        Assert.True(certMount.IsReadOnly);
+
+        var keyMount = Assert.Single(mounts, mount => mount.Source == keyPath);
+        Assert.Equal(expectedKeyTarget, keyMount.Target);
+        Assert.Equal(ContainerMountType.BindMount, keyMount.Type);
+        Assert.True(keyMount.IsReadOnly);
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(expectedCertTarget, env["CERT_PATH"]);
+        Assert.Equal(expectedKeyTarget, env["KEY_FILE"]);
+    }
+
+    [Theory]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    public async Task WithTelemetryAddsEnvironmentVariable(bool enabled, string expectedValue)
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTelemetry(enabled);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(expectedValue, env["ENABLE_TELEMETRY"]);
+    }
+
+    [Fact]
+    public async Task WithoutExtendedRumAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithoutExtendedRum();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["DISABLE_EXTENDED_RUM"]);
+    }
+
+    [Fact]
+    public async Task WithOwnerAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOwner("contoso");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("contoso", env["OWNER"]);
+    }
+
+    [Fact]
+    public async Task VerifyManifestIncludesAdditionalConfigurationOptions()
+    {
+        var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.pem"));
+        var keyPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.key"));
+        var initDataPath = Path.GetFullPath(Path.Combine("TestData", "init"));
+        var expectedCertTarget = $"/documentdb-cert-{Path.GetFileName(certPath)}";
+        var expectedKeyTarget = $"/documentdb-key-{Path.GetFileName(keyPath)}";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithLogLevel(DocumentDBLogLevel.Debug)
+            .WithInitData(initDataPath)
+            .WithTlsCertificate(certPath, keyPath)
+            .WithTelemetry(enabled: false)
+            .WithoutExtendedRum()
+            .WithOwner("contoso");
+
+        var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
+
+        Assert.Equal("debug", manifest["env"]?["LOG_LEVEL"]?.GetValue<string>());
+        Assert.Equal("/init_doc_db.d", manifest["env"]?["INIT_DATA_PATH"]?.GetValue<string>());
+        Assert.Equal("true", manifest["env"]?["SKIP_INIT_DATA"]?.GetValue<string>());
+        Assert.Equal(expectedCertTarget, manifest["env"]?["CERT_PATH"]?.GetValue<string>());
+        Assert.Equal(expectedKeyTarget, manifest["env"]?["KEY_FILE"]?.GetValue<string>());
+        Assert.Equal("false", manifest["env"]?["ENABLE_TELEMETRY"]?.GetValue<string>());
+        Assert.Equal("true", manifest["env"]?["DISABLE_EXTENDED_RUM"]?.GetValue<string>());
+        Assert.Equal("contoso", manifest["env"]?["OWNER"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task WithTlsCertificateUsesDistinctTargetsWhenFileNamesMatch()
+    {
+        var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "shared.pem"));
+        var keyPath = Path.GetFullPath(Path.Combine("TestData", "keys", "shared.pem"));
+        var expectedCertTarget = "/documentdb-cert-shared.pem";
+        var expectedKeyTarget = "/documentdb-key-shared.pem";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTlsCertificate(certPath, keyPath);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        Assert.True(containerResource.TryGetContainerMounts(out var mounts));
+        var certMount = Assert.Single(mounts, mount => mount.Source == certPath);
+        var keyMount = Assert.Single(mounts, mount => mount.Source == keyPath);
+
+        Assert.Equal(expectedCertTarget, certMount.Target);
+        Assert.Equal(expectedKeyTarget, keyMount.Target);
+        Assert.NotEqual(certMount.Target, keyMount.Target);
+
+        var env = await GetEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(expectedCertTarget, env["CERT_PATH"]);
+        Assert.Equal(expectedKeyTarget, env["KEY_FILE"]);
+    }
+
+    private static async Task<Dictionary<string, string>> GetEnvironmentVariablesAsync(DocumentDBServerResource resource)
+    {
+        var configuration = await ExecutionConfigurationBuilder
+            .Create(resource)
+            .WithEnvironmentVariablesConfig()
+            .BuildAsync(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish), NullLogger.Instance, default);
+
+        return configuration.EnvironmentVariables.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal);
     }
 }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Hosting.DocumentDB\Aspire.Hosting.DocumentDB.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.DocumentDB.EndToEndApp\Aspire.Hosting.DocumentDB.EndToEndApp.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj" />
     <PackageReference Include="Aspire.MongoDB.Driver" />
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
@@ -5,6 +5,9 @@ using Aspire.Hosting.Testing;
 using Aspire.TestUtilities;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using System.Net.Sockets;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Xunit;
 using Xunit.Sdk;
 
@@ -50,6 +53,54 @@ public class DocumentDBIntegrationTests
         Assert.Equal(0, await collection.CountDocumentsAsync(filter, cancellationToken: cts.Token));
     }
 
+    [Fact]
+    public async Task ConfiguredEndToEndAppAppliesAdditionalContainerOptions()
+    {
+        if (!RequiresDockerAttribute.IsSupported)
+        {
+            throw SkipException.ForSkip("Docker is required for DocumentDB end-to-end validation.");
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.Program>(cts.Token);
+        await using var app = await appHost.BuildAsync(cts.Token);
+
+        await app.StartAsync(cts.Token);
+
+        var connectionString = await app.GetConnectionStringAsync("appdb", cts.Token);
+        Assert.False(string.IsNullOrWhiteSpace(connectionString));
+
+        const string databaseName = "appdb";
+        var database = await ConnectAsync(connectionString!, databaseName, cts.Token);
+        var collection = database.GetCollection<BsonDocument>("widgets");
+
+        var seededDocument = await WaitForDocumentAsync(
+            collection,
+            Builders<BsonDocument>.Filter.Eq("_id", "seeded-widget"),
+            cts.Token);
+        Assert.NotNull(seededDocument);
+        Assert.Equal("custom-init", seededDocument["source"].AsString);
+
+        using var databaseNamesCursor = await database.Client.ListDatabaseNamesAsync(cancellationToken: cts.Token);
+        var databaseNames = await databaseNamesCursor.ToListAsync(cts.Token);
+        Assert.DoesNotContain("sampledb", databaseNames);
+
+        using var certificate = await GetRemoteCertificateAsync(connectionString!, cts.Token);
+        Assert.Contains("CN=Aspire.Hosting.DocumentDB.E2E", certificate.Subject, StringComparison.Ordinal);
+
+        var id = ObjectId.GenerateNewId();
+        var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+        var document = new BsonDocument
+        {
+            ["_id"] = id,
+            ["name"] = "configured-widget"
+        };
+
+        await collection.InsertOneAsync(document, cancellationToken: cts.Token);
+        Assert.Equal(1, await collection.CountDocumentsAsync(filter, cancellationToken: cts.Token));
+    }
+
     private static async Task<IMongoDatabase> ConnectAsync(string connectionString, string databaseName, CancellationToken cancellationToken)
     {
         var settings = MongoClientSettings.FromConnectionString(connectionString);
@@ -82,5 +133,46 @@ public class DocumentDBIntegrationTests
         }
 
         throw new InvalidOperationException("DocumentDB did not become reachable in time.", lastException);
+    }
+
+    private static async Task<X509Certificate2> GetRemoteCertificateAsync(string connectionString, CancellationToken cancellationToken)
+    {
+        var mongoUrl = MongoUrl.Create(connectionString);
+        var host = mongoUrl.Server.Host;
+        var port = mongoUrl.Server.Port;
+
+        using var tcpClient = new TcpClient();
+        await tcpClient.ConnectAsync(host, port, cancellationToken);
+
+        using var sslStream = new SslStream(
+            tcpClient.GetStream(),
+            leaveInnerStreamOpen: false,
+            userCertificateValidationCallback: static (_, _, _, _) => true);
+
+        await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+        {
+            TargetHost = host
+        }, cancellationToken);
+
+        return new X509Certificate2(sslStream.RemoteCertificate ?? throw new InvalidOperationException("Remote certificate was not available."));
+    }
+
+    private static async Task<BsonDocument?> WaitForDocumentAsync(
+        IMongoCollection<BsonDocument> collection,
+        FilterDefinition<BsonDocument> filter,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var document = await collection.Find(filter).SingleOrDefaultAsync(cancellationToken);
+            if (document is not null)
+            {
+                return document;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+
+        return null;
     }
 }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -136,6 +136,146 @@ public class DocumentDBPublicApiTests
         Assert.Equal(nameof(source), exception.ParamName);
     }
 
+    [Fact]
+    public void WithLogLevelShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithLogLevel(DocumentDBLogLevel.Info);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithInitDataShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+        const string source = "/DocumentDB/init";
+
+        var action = () => builder.WithInitData(source);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithInitDataShouldThrowWhenSourceIsNullOrEmpty(bool isNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+        var source = isNull ? null! : string.Empty;
+
+        var action = () => builder.WithInitData(source);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(source), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithoutSampleDataShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithoutSampleData();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithTlsCertificateShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+        const string certPath = "/DocumentDB/cert.pem";
+        const string keyPath = "/DocumentDB/key.pem";
+
+        var action = () => builder.WithTlsCertificate(certPath, keyPath);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true, false, "certPath")]
+    [InlineData(false, true, "certPath")]
+    [InlineData(false, false, "keyPath")]
+    public void WithTlsCertificateShouldThrowWhenPathIsNullOrEmpty(bool certIsNull, bool certIsEmpty, string expectedParamName)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+        var certPath = certIsNull ? null! : certIsEmpty ? string.Empty : "/DocumentDB/cert.pem";
+        var keyPath = certIsNull || certIsEmpty ? "/DocumentDB/key.pem" : null!;
+
+        if (expectedParamName == "keyPath")
+        {
+            certPath = "/DocumentDB/cert.pem";
+            keyPath = string.Empty;
+        }
+
+        var action = () => builder.WithTlsCertificate(certPath, keyPath);
+
+        var exception = certIsNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Fact]
+    public void WithTelemetryShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithTelemetry();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithoutExtendedRumShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithoutExtendedRum();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithOwnerShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+        const string owner = "documentdb";
+
+        var action = () => builder.WithOwner(owner);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithOwnerShouldThrowWhenOwnerIsNullOrEmpty(bool isNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+        var owner = isNull ? null! : string.Empty;
+
+        var action = () => builder.WithOwner(owner);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(owner), exception.ParamName);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -201,25 +201,18 @@ public class DocumentDBPublicApiTests
     }
 
     [Theory]
-    [InlineData(true, false, "certPath")]
-    [InlineData(false, true, "certPath")]
-    [InlineData(false, false, "keyPath")]
-    public void WithTlsCertificateShouldThrowWhenPathIsNullOrEmpty(bool certIsNull, bool certIsEmpty, string expectedParamName)
+    [InlineData(null, "/DocumentDB/key.pem", "certPath", true)]
+    [InlineData("", "/DocumentDB/key.pem", "certPath", false)]
+    [InlineData("/DocumentDB/cert.pem", null, "keyPath", true)]
+    [InlineData("/DocumentDB/cert.pem", "", "keyPath", false)]
+    public void WithTlsCertificateShouldThrowWhenPathIsNullOrEmpty(string? certPath, string? keyPath, string expectedParamName, bool expectNull)
     {
         var builder = TestDistributedApplicationBuilder.Create()
             .AddDocumentDB("DocumentDB");
-        var certPath = certIsNull ? null! : certIsEmpty ? string.Empty : "/DocumentDB/cert.pem";
-        var keyPath = certIsNull || certIsEmpty ? "/DocumentDB/key.pem" : null!;
 
-        if (expectedParamName == "keyPath")
-        {
-            certPath = "/DocumentDB/cert.pem";
-            keyPath = string.Empty;
-        }
+        var action = () => builder.WithTlsCertificate(certPath!, keyPath!);
 
-        var action = () => builder.WithTlsCertificate(certPath, keyPath);
-
-        var exception = certIsNull
+        var exception = expectNull
             ? Assert.Throws<ArgumentNullException>(action)
             : Assert.Throws<ArgumentException>(action);
         Assert.Equal(expectedParamName, exception.ParamName);


### PR DESCRIPTION
## Summary

Closes documentdb/documentdb#559

The DocumentDB Local container supports many configuration options via environment variables (log level, data initialization, TLS certificates, telemetry, etc.) that were not previously accessible through the Aspire hosting API. This limited the developer experience for debugging, data seeding, and closer-to-production local testing.

This PR exposes those options as fluent builder APIs, following the same patterns used by other Aspire database integrations.

### New APIs

```csharp
builder.AddDocumentDB("docdb")
    .WithLogLevel(DocumentDBLogLevel.Debug)       // Set container log verbosity
    .WithInitData("../seed")                       // Mount initialization scripts
    .WithoutSampleData()                           // Skip built-in sample collections
    .WithTlsCertificate("cert.pem", "cert.key")   // Use custom TLS certificate
    .WithTelemetry(enabled: false)                 // Disable telemetry
    .WithoutExtendedRum()                          // Disable extended RUM
    .WithOwner("documentdb");                      // Set resource owner
```

### Changes

| Area | Description |
|------|-------------|
| **`DocumentDBLogLevel` enum** | Maps log verbosity levels (Quiet, Error, Warn, Info, Debug, Trace) to container env values |
| **`WithLogLevel()`** | Sets `LOG_LEVEL` environment variable on the container |
| **`WithInitData(source)`** | Bind-mounts a host directory to `/init_doc_db.d` and implicitly disables sample data |
| **`WithoutSampleData()`** | Sets `SKIP_INIT_DATA=true` to suppress built-in sample collections |
| **`WithTlsCertificate(cert, key)`** | Bind-mounts custom TLS cert and key to distinct container paths, avoiding the mount collision that occurred when cert and key shared the same target directory |
| **`WithTelemetry(bool)`** | Controls the `ENABLE_TELEMETRY` environment variable |
| **`WithoutExtendedRum()`** | Sets `DISABLE_EXTENDED_RUM=true` |
| **`WithOwner(string)`** | Sets the `OWNER` environment variable |
| **Public API surface** | Updated to include all new methods and the enum |
| **README** | Documents all new configuration options with code samples |

### Removed

- **`WithPostgreSqlAccess()`** was removed from the extension surface. Direct PostgreSQL access is an internal implementation detail of DocumentDB and exposing it through the Aspire API would create a confusing developer experience. Users who need raw PostgreSQL access can connect directly to the container port.

### Bug Fix

- **TLS mount collision**: Previously, mounting both a TLS certificate and key file would collide because they targeted the same container directory. The fix uses distinct target paths (`/etc/documentdb/cert.pem` and `/etc/documentdb/key.pem`) so both files can be mounted simultaneously.

### Testing

- New unit tests for mounts, environment variables, and manifest output for each configuration option
- New argument-validation tests for all public API null guards
- New end-to-end app (`ConfiguredEndToEndApp`) that exercises all configuration options together
- `dotnet test azure-databases-aspire.sln`

Related to documentdb/documentdb#559.