### PR TITLE
Add health checks for DocumentDB Aspire resources

### DIFF
--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -3,8 +3,8 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.DocumentDB;
-// using Microsoft.Extensions.DependencyInjection;
-// using MongoDB.Driver;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
 
 namespace Aspire.Hosting;
 
@@ -15,6 +15,7 @@ public static class DocumentDBBuilderExtensions
 {
     // default internal port is 10260.
     private const int DefaultContainerPort = 10260;
+    private const string DefaultHealthCheckDatabaseName = "admin";
 
     private const string UserEnvVarName = "USERNAME";
     private const string PasswordEnvVarName = "PASSWORD";
@@ -23,6 +24,9 @@ public static class DocumentDBBuilderExtensions
     /// Adds a DocumentDB resource to the application model. A container is used for local development.
     /// </summary>
     /// <remarks>
+    /// This resource includes a built-in health check. When this resource is referenced as a dependency
+    /// using the <see cref="ResourceBuilderExtensions.WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/>
+    /// extension method then the dependent resource will wait until the DocumentDB server responds to ping.
     /// This version of the package defaults to the <inheritdoc cref="DocumentDBContainerImageTags.Tag"/> tag of the <inheritdoc cref="DocumentDBContainerImageTags.Image"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
@@ -68,6 +72,16 @@ public static class DocumentDBBuilderExtensions
             }
         });
 
+        var healthCheckKey = $"{name}_check";
+        // Use a database-scoped check so the MongoDB health check package executes a ping command.
+        IMongoDatabase? database = null;
+        builder.Services.AddHealthChecks()
+            .AddMongoDb(
+                sp => database ??=
+                    new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
+                        .GetDatabase(DefaultHealthCheckDatabaseName),
+                name: healthCheckKey);
+
         return builder
             .AddResource(DocumentDBContainer)
             .WithEndpoint(port: port, targetPort: DefaultContainerPort, name: DocumentDBServerResource.PrimaryEndpointName)
@@ -77,8 +91,8 @@ public static class DocumentDBBuilderExtensions
             {
                 context.EnvironmentVariables[UserEnvVarName] = DocumentDBContainer.UserNameReference;
                 context.EnvironmentVariables[PasswordEnvVarName] = DocumentDBContainer.PasswordParameter!;
-            });
-        //.WithHealthCheck(healthCheckKey);
+            })
+            .WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>
@@ -88,6 +102,11 @@ public static class DocumentDBBuilderExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="databaseName">The name of the database. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// This resource includes a built-in health check. When this resource is referenced as a dependency
+    /// using the <see cref="ResourceBuilderExtensions.WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/>
+    /// extension method then the dependent resource will wait until the DocumentDB database responds to ping.
+    /// </remarks>
     public static IResourceBuilder<DocumentDBDatabaseResource> AddDatabase(this IResourceBuilder<DocumentDBServerResource> builder, [ResourceName] string name, string? databaseName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -96,8 +115,8 @@ public static class DocumentDBBuilderExtensions
         // Use the resource name as the database name if it's not provided
         databaseName ??= name;
 
-    var DocumentDBDatabase = new DocumentDBDatabaseResource(name, databaseName, builder.Resource);
-    builder.Resource.AddDatabase(DocumentDBDatabase);
+        var DocumentDBDatabase = new DocumentDBDatabaseResource(name, databaseName, builder.Resource);
+        builder.Resource.AddDatabase(DocumentDBDatabase);
 
         string? connectionString = null;
 
@@ -111,18 +130,19 @@ public static class DocumentDBBuilderExtensions
             }
         });
 
-        // var healthCheckKey = $"{name}_check";
-        // // cache the database client so it is reused on subsequent calls to the health check
-        // IMongoDatabase? database = null;
-        // builder.ApplicationBuilder.Services.AddHealthChecks()
-        //     .AddDocumentDB(
-        //         sp => database ??=
-        //             new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
-        //                 .GetDatabase(databaseName),
-        //         name: healthCheckKey);
+        var healthCheckKey = $"{name}_check";
+        // cache the database client so it is reused on subsequent calls to the health check
+        IMongoDatabase? database = null;
+        builder.ApplicationBuilder.Services.AddHealthChecks()
+            .AddMongoDb(
+                sp => database ??=
+                    new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
+                        .GetDatabase(databaseName),
+                name: healthCheckKey);
 
         return builder.ApplicationBuilder
-            .AddResource(DocumentDBDatabase);
+            .AddResource(DocumentDBDatabase)
+            .WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -77,7 +77,7 @@ public static class DocumentDBBuilderExtensions
         IMongoDatabase? database = null;
         builder.Services.AddHealthChecks()
             .AddMongoDb(
-                sp => database ??=
+                _ => database ??=
                     new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
                         .GetDatabase(DefaultHealthCheckDatabaseName),
                 name: healthCheckKey);
@@ -131,11 +131,11 @@ public static class DocumentDBBuilderExtensions
         });
 
         var healthCheckKey = $"{name}_check";
-        // cache the database client so it is reused on subsequent calls to the health check
+        // cache the database instance so it is reused on subsequent calls to the health check
         IMongoDatabase? database = null;
         builder.ApplicationBuilder.Services.AddHealthChecks()
             .AddMongoDb(
-                sp => database ??=
+                _ => database ??=
                     new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
                         .GetDatabase(databaseName),
                 name: healthCheckKey);

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -5,12 +5,51 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Aspire.Hosting.DocumentDB.Tests;
 
 public class AddDocumentDBTests
 {
+    [Fact]
+    public void AddDocumentDBAddsHealthCheckAnnotationToResource()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var documentDB = appBuilder.AddDocumentDB("documentdb");
+
+        Assert.Single(documentDB.Resource.Annotations, a => a is HealthCheckAnnotation hca && hca.Key == "documentdb_check");
+    }
+
+    [Fact]
+    public void AddDatabaseAddsHealthCheckAnnotationToResource()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var database = appBuilder.AddDocumentDB("documentdb")
+            .AddDatabase("appdb");
+
+        Assert.Single(database.Resource.Annotations, a => a is HealthCheckAnnotation hca && hca.Key == "appdb_check");
+    }
+
+    [Fact]
+    public void AddDocumentDBRegistersServerAndDatabaseHealthChecks()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("documentdb")
+            .AddDatabase("appdb");
+
+        using var app = appBuilder.Build();
+
+        var healthCheckOptions = app.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Contains(healthCheckOptions.Registrations, registration => registration.Name == "documentdb_check");
+        Assert.Contains(healthCheckOptions.Registrations, registration => registration.Name == "appdb_check");
+        Assert.NotNull(app.Services.GetRequiredService<HealthCheckService>());
+    }
+
     [Fact]
     public void AddDocumentDBContainerWithDefaultsAddsAnnotationMetadata()
     {

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
@@ -3,6 +3,8 @@
 
 using Aspire.Hosting.Testing;
 using Aspire.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Xunit;
@@ -26,6 +28,10 @@ public class DocumentDBIntegrationTests
         await using var app = await appHost.BuildAsync(cts.Token);
 
         await app.StartAsync(cts.Token);
+
+        var healthCheckService = app.Services.GetRequiredService<HealthCheckService>();
+        await WaitForHealthCheckAsync(healthCheckService, "documentdb_check", cts.Token);
+        await WaitForHealthCheckAsync(healthCheckService, "appdb_check", cts.Token);
 
         var connectionString = await app.GetConnectionStringAsync("appdb", cts.Token);
         Assert.False(string.IsNullOrWhiteSpace(connectionString));
@@ -82,5 +88,32 @@ public class DocumentDBIntegrationTests
         }
 
         throw new InvalidOperationException("DocumentDB did not become reachable in time.", lastException);
+    }
+
+    private static async Task WaitForHealthCheckAsync(HealthCheckService healthCheckService, string healthCheckKey, CancellationToken cancellationToken)
+    {
+        HealthReport? lastReport = null;
+
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            lastReport = await healthCheckService.CheckHealthAsync(
+                registration => registration.Name == healthCheckKey,
+                cancellationToken);
+
+            if (lastReport.Entries.TryGetValue(healthCheckKey, out var entry) && entry.Status == HealthStatus.Healthy)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+
+        var lastMessage = "The health check registration was not found.";
+        if (lastReport is not null && lastReport.Entries.TryGetValue(healthCheckKey, out var lastEntry))
+        {
+            lastMessage = $"{lastEntry.Status}: {lastEntry.Description}";
+        }
+
+        throw new InvalidOperationException($"Health check '{healthCheckKey}' did not become healthy in time. Last result: {lastMessage}");
     }
 }


### PR DESCRIPTION
## Summary

Closes documentdb/documentdb#558

The Aspire integration had health check code that was entirely commented out. Without active health checks, the Aspire dashboard showed DocumentDB resources in an unknown health state, and dependent services using `WaitFor()` could not wait for DocumentDB readiness before starting.

This PR enables health checks for both DocumentDB server and database resources using the `AspNetCore.HealthChecks.MongoDb` package, which executes a `ping` command against the server -- a lightweight, unauthenticated probe that DocumentDB supports natively.

### How It Works

- **Server-level health check**: Registers a MongoDB health check that pings the `admin` database on the DocumentDB server
- **Database-level health check**: Registers a MongoDB health check that pings the specific named database
- Both checks are associated with their Aspire resources via `WithHealthCheck()`, so the dashboard reflects real health status and `WaitFor()` blocks until the resource responds

```csharp
// WaitFor now works correctly with DocumentDB resources
var docdb = builder.AddDocumentDB("docdb");
var db = docdb.AddDatabase("appdb");

builder.AddProject<MyApp>("myapp")
    .WithReference(db)
    .WaitFor(db);  // blocks until health check passes
```

### Changes

| Area | Description |
|------|-------------|
| **`AddDocumentDB()`** | Registers a server-scoped MongoDB health check and wires it to the resource via `WithHealthCheck()` |
| **`AddDatabase()`** | Registers a database-scoped MongoDB health check and wires it to the resource via `WithHealthCheck()` |
| **XML docs** | Added `<remarks>` sections documenting the built-in health check behavior on both methods |
| **Unit tests** | Verifies health check annotations are present on server and database resources, and that `HealthCheckServiceOptions` contains the expected registrations |
| **End-to-end tests** | Validates that both server and database health checks become healthy after container startup |

### Testing

- `dotnet build azure-databases-aspire.sln`
- `dotnet test azure-databases-aspire.sln --no-build`

References documentdb/documentdb#558