### PR TITLE
Improve Aspire.Hosting.DocumentDB documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - NuGet package metadata (description, tags, icon, license, project URL)
 - NuGet publish workflow for automated releases on version tags
-- `WithDataVolume` now accepts a `targetPath` parameter for custom mount paths
 - `UseTls()` and `AllowInsecureTls()` extension methods for explicit TLS control
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `UseTls()` and `AllowInsecureTls()` extension methods for explicit TLS control
 
 ### Changed
-- Upgraded to .NET Aspire 13.1.2
+- Upgraded to .NET Aspire 13.2.2
 - Default container image updated to `ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.109.0`
 - TLS is now enabled by default (`tls=true&tlsInsecure=true`) for the local container's self-signed certificate
 - Uses `tlsInsecure=true` instead of `tlsAllowInvalidCertificates=true` for better .NET MongoDB driver compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to the `Aspire.Hosting.DocumentDB` package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project uses [MinVer](https://github.com/adamralph/minver) for versioning based on Git tags.
+
+## [0.109.0] - 2026-04-07
+
+### Added
+- NuGet package metadata (description, tags, icon, license, project URL)
+- NuGet publish workflow for automated releases on version tags
+- `WithDataVolume` now accepts a `targetPath` parameter for custom mount paths
+- `UseTls()` and `AllowInsecureTls()` extension methods for explicit TLS control
+
+### Changed
+- Upgraded to .NET Aspire 13.1.2
+- Default container image updated to `ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.109.0`
+- TLS is now enabled by default (`tls=true&tlsInsecure=true`) for the local container's self-signed certificate
+- Uses `tlsInsecure=true` instead of `tlsAllowInvalidCertificates=true` for better .NET MongoDB driver compatibility
+
+### Fixed
+- Connection string TLS handling for .NET MongoDB driver self-signed certificate validation
+
+## [0.1.0] - 2025-08-20
+
+### Added
+- Initial release of `Aspire.Hosting.DocumentDB`
+- `AddDocumentDB()` extension method for adding a DocumentDB server resource
+- `AddDatabase()` extension method for adding database child resources
+- `WithHostPort()` for fixed port binding
+- `WithDataVolume()` for Docker volume persistence
+- `WithDataBindMount()` for host directory persistence
+- Auto-generated connection strings with MongoDB wire protocol
+- SCRAM-SHA-256 authentication support
+- Container image: `ghcr.io/documentdb/documentdb/documentdb-local`
+
+[0.109.0]: https://github.com/microsoft/azure-databases-aspire/releases/tag/v0.109.0
+[0.1.0]: https://github.com/microsoft/azure-databases-aspire/compare/32cee17...4aa9aac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 - Connection string TLS handling for .NET MongoDB driver self-signed certificate validation
+- `WithHostPort()` now updates the correct `tcp` endpoint (previously referenced `http`)
 
 ## [0.1.0] - 2025-08-20
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/int
 
 This package lets you add a DocumentDB container to your Aspire AppHost with a single line of code. Connection strings, credentials, TLS, and container lifecycle are managed automatically.
 
-## Quick Start
+## Quick start
 
 ### Prerequisites
 
@@ -15,7 +15,7 @@ This package lets you add a DocumentDB container to your Aspire AppHost with a s
 - [.NET Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
 - [Docker](https://www.docker.com/products/docker-desktop/) (DocumentDB runs as a Linux container)
 
-### 1. Install the package
+### Install the package
 
 In your Aspire **AppHost** project:
 
@@ -23,7 +23,7 @@ In your Aspire **AppHost** project:
 dotnet add package Aspire.Hosting.DocumentDB
 ```
 
-### 2. Add DocumentDB to your AppHost
+### Add DocumentDB to your AppHost
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -38,7 +38,7 @@ builder.AddProject<Projects.MyService>()
 builder.Build().Run();
 ```
 
-### 3. Use MongoDB client in your service
+### Use MongoDB client in your service
 
 In your service project, install and register the MongoDB driver:
 
@@ -52,7 +52,7 @@ builder.AddMongoDBClient("mydb");
 
 Then inject `IMongoClient` wherever you need it. The connection string is resolved automatically.
 
-## Configuration Methods
+## Configuration methods
 
 | Method | Description |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package lets you add a DocumentDB container to your Aspire AppHost with a s
 
 ### Prerequisites
 
-- [.NET 9 SDK](https://dotnet.microsoft.com/download) or later
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) or later
 - [.NET Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
 - [Docker](https://www.docker.com/products/docker-desktop/) (DocumentDB runs as a Linux container)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var db = builder.AddDocumentDB("documentdb")
                 .AddDatabase("mydb");
 
-builder.AddProject<Projects.MyService>()
+builder.AddProject<Projects.MyService>("myservice")
        .WithReference(db)
        .WaitFor(db);
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,106 @@
-# .NET Aspire Azure Databases Integrations
+# Aspire.Hosting.DocumentDB
 
-This repository contains .NET Aspire hosting integrations for database services.
+[![NuGet](https://img.shields.io/nuget/v/Aspire.Hosting.DocumentDB.svg)](https://www.nuget.org/packages/Aspire.Hosting.DocumentDB)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/integrations-overview) is an opinionated, cloud-ready stack for building observable, production-ready, distributed applications. [Aspire integrations](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/integrations-overview) are a curated suite of NuGet packages selected to facilitate the integration of cloud-native applications with prominent services and platforms, such as Redis and PostgreSQL. Each integration furnishes essential cloud-native functionalities through either automatic provisioning or standardized configuration patterns.
+A [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/integrations-overview) hosting integration for [DocumentDB](https://github.com/documentdb/documentdb), the open-source MongoDB-compatible document database built on PostgreSQL.
 
-## Available Integrations
+This package lets you add a DocumentDB container to your Aspire AppHost with a single line of code. Connection strings, credentials, TLS, and container lifecycle are managed automatically.
 
-- `Aspire.Hosting.DocumentDB` - Provides extension methods and resource definitions for a .NET Aspire AppHost to configure a [DocumentDB](https://github.com/microsoft/documentdb) resource. Check [README](src/Aspire.Hosting.DocumentDB/README.md) for details.
+## Quick Start
+
+### Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download) or later
+- [.NET Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
+- [Docker](https://www.docker.com/products/docker-desktop/) (DocumentDB runs as a Linux container)
+
+### 1. Install the package
+
+In your Aspire **AppHost** project:
+
+```bash
+dotnet add package Aspire.Hosting.DocumentDB
+```
+
+### 2. Add DocumentDB to your AppHost
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var db = builder.AddDocumentDB("documentdb")
+                .AddDatabase("mydb");
+
+builder.AddProject<Projects.MyService>()
+       .WithReference(db)
+       .WaitFor(db);
+
+builder.Build().Run();
+```
+
+### 3. Use MongoDB client in your service
+
+In your service project, install and register the MongoDB driver:
+
+```bash
+dotnet add package Aspire.MongoDB.Driver
+```
+
+```csharp
+builder.AddMongoDBClient("mydb");
+```
+
+Then inject `IMongoClient` wherever you need it. The connection string is resolved automatically.
+
+## Configuration Methods
+
+| Method | Description |
+|---|---|
+| `AddDocumentDB(name, port?, userName?, password?)` | Add a DocumentDB server resource |
+| `.AddDatabase(name, databaseName?)` | Add a database on the server |
+| `.WithHostPort(port)` | Bind to a specific host port |
+| `.WithDataVolume(name?, isReadOnly?, targetPath?)` | Persist data with a Docker volume |
+| `.WithDataBindMount(source, isReadOnly?)` | Persist data with a host directory mount |
+| `.UseTls(useTls?)` | Enable/disable TLS (default: enabled) |
+| `.AllowInsecureTls(allowInsecureTls?)` | Allow self-signed certificates (default: enabled) |
+
+See the [Configuration Reference](docs/configuration.md) for details, code examples, and default values.
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Step-by-step guide to set up DocumentDB in an Aspire app |
+| [Configuration Reference](docs/configuration.md) | All methods, parameters, defaults, and connection string format |
+| [Troubleshooting](docs/troubleshooting.md) | Common issues and solutions |
+| [Changelog](CHANGELOG.md) | Release history |
+| [NuGet Package README](src/Aspire.Hosting.DocumentDB/README.md) | Package overview shown on nuget.org |
+
+## About DocumentDB
+
+[DocumentDB](https://github.com/documentdb/documentdb) is an open-source document database that provides MongoDB compatibility on top of PostgreSQL. It supports:
+
+- Full MongoDB CRUD API via the MongoDB wire protocol
+- BSON document storage
+- Rich query support including aggregation pipelines
+- Full-text, geospatial, and vector search
+- SCRAM-SHA-256 authentication with TLS
+
+The Aspire integration runs the [`documentdb-local`](https://ghcr.io/documentdb/documentdb/documentdb-local) container image, which bundles the DocumentDB gateway and PostgreSQL backend in a single container.
+
+## Contributing
+
+Contributions are welcome. Please open an issue first to discuss the change you'd like to make.
+
+To build and test locally:
+
+```bash
+dotnet build azure-databases-aspire.sln
+dotnet test azure-databases-aspire.sln
+```
+
+End-to-end tests require a running Docker daemon.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ The extension passes these environment variables to the DocumentDB container:
 |---|---|---|
 | `USERNAME` | The configured username | Container creates this user on startup |
 | `PASSWORD` | The configured password | Password for the created user |
-| `DATA_PATH` | `/home/documentdb/postgresql/data` | Only set when using `WithDataVolume` or `WithDataBindMount` |
+| `DATA_PATH` | Path inside the container for the data directory (default: `/home/documentdb/postgresql/data`) | Only set when using `WithDataVolume` or `WithDataBindMount` |
 
 ## Resource model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
-# Configuration Reference
+# Configuration reference
 
 This page documents every public API method in `Aspire.Hosting.DocumentDB` with usage examples and default values.
 
 ## AddDocumentDB
 
-Adds a DocumentDB server resource to the Aspire application model. A container is started for local development.
+The extension adds a DocumentDB server resource to the Aspire application model. A container is started for local development.
 
 ```csharp
 // Minimal -- random port, generated credentials
@@ -105,7 +105,7 @@ The data is mounted at `/home/documentdb/postgresql/data` inside the container. 
 Controls whether TLS is included in the generated connection string. TLS is **enabled by default** because the DocumentDB Local container requires TLS connections.
 
 ```csharp
-// Disable TLS (e.g., connecting to a non-TLS endpoint)
+// Disable TLS (for example, connecting to a non-TLS endpoint)
 var server = builder.AddDocumentDB("documentdb")
                     .UseTls(false);
 
@@ -123,7 +123,7 @@ var server = builder.AddDocumentDB("documentdb")
 Controls whether `tlsInsecure=true` is added to the connection string, which disables certificate validation. This is **enabled by default** so the .NET MongoDB driver can connect to the self-signed certificate used by the DocumentDB Local container.
 
 ```csharp
-// Require valid certificates (e.g., production with real certs)
+// Require valid certificates (for example, production with real certs)
 var server = builder.AddDocumentDB("documentdb")
                     .AllowInsecureTls(false);
 ```
@@ -132,9 +132,10 @@ var server = builder.AddDocumentDB("documentdb")
 |---|---|---|---|
 | `allowInsecureTls` | `bool` | `true` | Whether to add `tlsInsecure=true` to the connection string. |
 
-> **Note:** The extension uses `tlsInsecure=true` rather than `tlsAllowInvalidCertificates=true` because the .NET MongoDB driver does not fully honor `tlsAllowInvalidCertificates` for self-signed certificates and raises `UntrustedRoot` errors. `tlsInsecure=true` disables both certificate validation and hostname verification, which is the correct setting for local development containers.
+> [!NOTE]
+> The extension uses `tlsInsecure=true` rather than `tlsAllowInvalidCertificates=true` because the .NET MongoDB driver does not fully honor `tlsAllowInvalidCertificates` for self-signed certificates and raises `UntrustedRoot` errors. `tlsInsecure=true` disables both certificate validation and hostname verification, which is the correct setting for local development containers.
 
-## Connection String Format
+## Connection string format
 
 The extension generates a MongoDB connection string with the following format:
 
@@ -156,7 +157,7 @@ mongodb://<username>:<password>@<host>:<port>[/<database>]?authSource=admin&auth
 | `tls` | `true` | Controlled by `UseTls()` |
 | `tlsInsecure` | `true` | Controlled by `AllowInsecureTls()` |
 
-## Defaults Summary
+## Defaults summary
 
 | Setting | Default Value |
 |---|---|
@@ -172,7 +173,7 @@ mongodb://<username>:<password>@<host>:<port>[/<database>]?authSource=admin&auth
 | Auth mechanism | `SCRAM-SHA-256` |
 | Auth database | `admin` |
 
-## Container Environment Variables
+## Container environment variables
 
 The extension passes these environment variables to the DocumentDB container:
 
@@ -182,7 +183,7 @@ The extension passes these environment variables to the DocumentDB container:
 | `PASSWORD` | The configured password | Password for the created user |
 | `DATA_PATH` | `/home/documentdb/postgresql/data` | Only set when using `WithDataVolume` or `WithDataBindMount` |
 
-## Resource Model
+## Resource model
 
 The extension defines two resource types:
 
@@ -198,10 +199,10 @@ IDistributedApplicationBuilder
                     +-- DocumentDBDatabaseResource  (child resource with connection string)
 ```
 
-- **DocumentDBServerResource** -- Represents the DocumentDB container. Implements `IResourceWithConnectionString`. The server-level connection string does not include a database name.
-- **DocumentDBDatabaseResource** -- A child resource that represents a specific database on the server. Its connection string includes the database name in the path. This is what services typically reference with `WithReference()`.
+- **DocumentDBServerResource** — Represents the DocumentDB container. Implements `IResourceWithConnectionString`. The server-level connection string does not include a database name.
+- **DocumentDBDatabaseResource** — A child resource that represents a specific database on the server. Its connection string includes the database name in the path. This is what services typically reference with `WithReference()`.
 
-## Chaining Methods
+## Chaining methods
 
 All configuration methods return the builder, so they can be chained:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,8 +156,6 @@ mongodb://<username>:<password>@<host>:<port>[/<database>]?authSource=admin&auth
 | `tls` | `true` | Controlled by `UseTls()` |
 | `tlsInsecure` | `true` | Controlled by `AllowInsecureTls()` |
 
-When no credentials are provided, the username/password and auth parameters are omitted from the connection string.
-
 ## Defaults Summary
 
 | Setting | Default Value |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,9 +80,9 @@ var server = builder.AddDocumentDB("documentdb")
 |---|---|---|---|
 | `name` | `string?` | Auto-generated | Docker volume name. When `null`, a name is generated from the application and resource names. |
 | `isReadOnly` | `bool` | `false` | Mount the volume as read-only. |
-| `targetPath` | `string?` | `/home/documentdb/postgresql/data` | Path inside the container where the volume is mounted. |
+| `targetPath` | `string?` | `/home/documentdb/postgresql/data` | Path inside the container where the volume is mounted when this helper is used. |
 
-The method also sets the `DATA_PATH` environment variable inside the container to match `targetPath`.
+The bare DocumentDB container defaults `DATA_PATH` to `/data`. This method mounts the volume at `targetPath` and sets the `DATA_PATH` environment variable to match, overriding the container default so DocumentDB writes to the mounted directory.
 
 ## WithDataBindMount
 
@@ -98,7 +98,7 @@ var server = builder.AddDocumentDB("documentdb")
 | `source` | `string` | (required) | Path on the host machine to mount. |
 | `isReadOnly` | `bool` | `false` | Mount as read-only. |
 
-The data is mounted at `/home/documentdb/postgresql/data` inside the container. The `DATA_PATH` environment variable is set accordingly.
+By default, this helper mounts data at `/home/documentdb/postgresql/data` inside the container and sets `DATA_PATH` accordingly. Without `WithDataVolume()` or `WithDataBindMount()`, the underlying DocumentDB container keeps its own default data path of `/data`.
 
 ## UseTls
 
@@ -169,7 +169,8 @@ mongodb://<username>:<password>@<host>:<port>[/<database>]?authSource=admin&auth
 | Password | Auto-generated (no special characters) |
 | TLS | Enabled |
 | Insecure TLS | Enabled (allows self-signed certificates) |
-| Data path (in container) | `/home/documentdb/postgresql/data` |
+| Container default data path | `/data` |
+| Persistence helper default path | `/home/documentdb/postgresql/data` |
 | Auth mechanism | `SCRAM-SHA-256` |
 | Auth database | `admin` |
 
@@ -181,7 +182,7 @@ The extension passes these environment variables to the DocumentDB container:
 |---|---|---|
 | `USERNAME` | The configured username | Container creates this user on startup |
 | `PASSWORD` | The configured password | Password for the created user |
-| `DATA_PATH` | Path inside the container for the data directory (default: `/home/documentdb/postgresql/data`) | Only set when using `WithDataVolume` or `WithDataBindMount` |
+| `DATA_PATH` | Path inside the container for the mounted data directory | Only set when using `WithDataVolume` or `WithDataBindMount`; otherwise the container uses its default `/data` |
 
 ## Resource model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 # Configuration reference
 
-This page documents every public API method in `Aspire.Hosting.DocumentDB` with usage examples and default values.
+This page covers the public API methods you can use in `Aspire.Hosting.DocumentDB`, along with usage examples and default values.
 
 ## AddDocumentDB
 
-The extension adds a DocumentDB server resource to the Aspire application model. A container is started for local development.
+The extension adds a DocumentDB server resource to the Aspire application model and starts a container for local development.
 
 ```csharp
 // Minimal -- random port, generated credentials
@@ -98,7 +98,7 @@ var server = builder.AddDocumentDB("documentdb")
 | `source` | `string` | (required) | Path on the host machine to mount. |
 | `isReadOnly` | `bool` | `false` | Mount as read-only. |
 
-By default, this helper mounts data at `/home/documentdb/postgresql/data` inside the container and sets `DATA_PATH` accordingly. Without `WithDataVolume()` or `WithDataBindMount()`, the underlying DocumentDB container keeps its own default data path of `/data`.
+By default, this helper mounts data at `/home/documentdb/postgresql/data` inside the container and sets `DATA_PATH` accordingly. If you do not call `WithDataVolume()` or `WithDataBindMount()`, the underlying DocumentDB container keeps its own default data path of `/data`.
 
 ## UseTls
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,217 @@
+# Configuration Reference
+
+This page documents every public API method in `Aspire.Hosting.DocumentDB` with usage examples and default values.
+
+## AddDocumentDB
+
+Adds a DocumentDB server resource to the Aspire application model. A container is started for local development.
+
+```csharp
+// Minimal -- random port, generated credentials
+var server = builder.AddDocumentDB("documentdb");
+
+// Fixed host port
+var server = builder.AddDocumentDB("documentdb", port: 10260);
+
+// Custom credentials via Aspire parameters
+var user = builder.AddParameter("db-user");
+var pass = builder.AddParameter("db-pass", secret: true);
+var server = builder.AddDocumentDB("documentdb", userName: user, password: pass);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | (required) | Resource name. Also used as the connection string name when referenced by services. |
+| `port` | `int?` | `null` (random) | Host port to expose. When `null`, Aspire assigns a random available port. |
+| `userName` | `IResourceBuilder<ParameterResource>?` | `null` | Custom username parameter. When `null`, defaults to `admin`. |
+| `password` | `IResourceBuilder<ParameterResource>?` | `null` | Custom password parameter. When `null`, a random password is generated. |
+
+## AddDatabase
+
+Adds a named database as a child resource of a DocumentDB server. Services reference the database resource to get a connection string that includes the database name.
+
+```csharp
+var db = builder.AddDocumentDB("documentdb")
+                .AddDatabase("mydb");
+
+// Custom database name (resource name differs from database name)
+var db = builder.AddDocumentDB("documentdb")
+                .AddDatabase("db-resource", databaseName: "actual_database_name");
+
+// Multiple databases on the same server
+var server = builder.AddDocumentDB("documentdb");
+var ordersDb = server.AddDatabase("orders");
+var usersDb = server.AddDatabase("users");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | (required) | Resource name. Used as the connection string name when referenced. |
+| `databaseName` | `string?` | Same as `name` | The actual database name in DocumentDB. Defaults to the resource `name` if not specified. |
+
+## WithHostPort
+
+Binds the DocumentDB container to a specific host port instead of a randomly assigned one. Useful for development when you want a predictable port.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithHostPort(10260);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `port` | `int?` | `null` (random) | The host port to bind. `null` reverts to a random port. |
+
+## WithDataVolume
+
+Attaches a Docker named volume to persist DocumentDB data across container restarts.
+
+```csharp
+// Auto-generated volume name
+var server = builder.AddDocumentDB("documentdb")
+                    .WithDataVolume();
+
+// Explicit volume name
+var server = builder.AddDocumentDB("documentdb")
+                    .WithDataVolume(name: "documentdb-data");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string?` | Auto-generated | Docker volume name. When `null`, a name is generated from the application and resource names. |
+| `isReadOnly` | `bool` | `false` | Mount the volume as read-only. |
+| `targetPath` | `string?` | `/home/documentdb/postgresql/data` | Path inside the container where the volume is mounted. |
+
+The method also sets the `DATA_PATH` environment variable inside the container to match `targetPath`.
+
+## WithDataBindMount
+
+Mounts a host directory into the container for data persistence. Prefer `WithDataVolume` for most cases; bind mounts are useful when you need direct access to the data files on the host.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithDataBindMount("./data/documentdb");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `source` | `string` | (required) | Path on the host machine to mount. |
+| `isReadOnly` | `bool` | `false` | Mount as read-only. |
+
+The data is mounted at `/home/documentdb/postgresql/data` inside the container. The `DATA_PATH` environment variable is set accordingly.
+
+## UseTls
+
+Controls whether TLS is included in the generated connection string. TLS is **enabled by default** because the DocumentDB Local container requires TLS connections.
+
+```csharp
+// Disable TLS (e.g., connecting to a non-TLS endpoint)
+var server = builder.AddDocumentDB("documentdb")
+                    .UseTls(false);
+
+// Explicitly enable TLS (this is the default)
+var server = builder.AddDocumentDB("documentdb")
+                    .UseTls(true);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `useTls` | `bool` | `true` | Whether to add `tls=true` to the connection string. |
+
+## AllowInsecureTls
+
+Controls whether `tlsInsecure=true` is added to the connection string, which disables certificate validation. This is **enabled by default** so the .NET MongoDB driver can connect to the self-signed certificate used by the DocumentDB Local container.
+
+```csharp
+// Require valid certificates (e.g., production with real certs)
+var server = builder.AddDocumentDB("documentdb")
+                    .AllowInsecureTls(false);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `allowInsecureTls` | `bool` | `true` | Whether to add `tlsInsecure=true` to the connection string. |
+
+> **Note:** The extension uses `tlsInsecure=true` rather than `tlsAllowInvalidCertificates=true` because the .NET MongoDB driver does not fully honor `tlsAllowInvalidCertificates` for self-signed certificates and raises `UntrustedRoot` errors. `tlsInsecure=true` disables both certificate validation and hostname verification, which is the correct setting for local development containers.
+
+## Connection String Format
+
+The extension generates a MongoDB connection string with the following format:
+
+```
+mongodb://<username>:<password>@<host>:<port>[/<database>]?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true
+```
+
+### Breakdown
+
+| Component | Value | Source |
+|---|---|---|
+| Protocol | `mongodb://` | Always MongoDB wire protocol |
+| Username | `admin` (default) or custom | `userName` parameter or default |
+| Password | Auto-generated or custom | `password` parameter or generated |
+| Host:Port | Allocated by Aspire | Endpoint binding |
+| Database | Resource name or `databaseName` | `AddDatabase()` parameter |
+| `authSource` | `admin` | Fixed authentication database |
+| `authMechanism` | `SCRAM-SHA-256` | DocumentDB authentication |
+| `tls` | `true` | Controlled by `UseTls()` |
+| `tlsInsecure` | `true` | Controlled by `AllowInsecureTls()` |
+
+When no credentials are provided, the username/password and auth parameters are omitted from the connection string.
+
+## Defaults Summary
+
+| Setting | Default Value |
+|---|---|
+| Container image | `ghcr.io/documentdb/documentdb/documentdb-local` |
+| Image tag | `pg17-0.109.0` |
+| Container port | `10260` |
+| Host port | Random (unless set with `WithHostPort` or `port` parameter) |
+| Username | `admin` |
+| Password | Auto-generated (no special characters) |
+| TLS | Enabled |
+| Insecure TLS | Enabled (allows self-signed certificates) |
+| Data path (in container) | `/home/documentdb/postgresql/data` |
+| Auth mechanism | `SCRAM-SHA-256` |
+| Auth database | `admin` |
+
+## Container Environment Variables
+
+The extension passes these environment variables to the DocumentDB container:
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `USERNAME` | The configured username | Container creates this user on startup |
+| `PASSWORD` | The configured password | Password for the created user |
+| `DATA_PATH` | `/home/documentdb/postgresql/data` | Only set when using `WithDataVolume` or `WithDataBindMount` |
+
+## Resource Model
+
+The extension defines two resource types:
+
+```
+IDistributedApplicationBuilder
+  |
+  +-- AddDocumentDB("server-name")
+        |
+        +-- DocumentDBServerResource  (container resource with connection string)
+              |
+              +-- AddDatabase("db-name")
+                    |
+                    +-- DocumentDBDatabaseResource  (child resource with connection string)
+```
+
+- **DocumentDBServerResource** -- Represents the DocumentDB container. Implements `IResourceWithConnectionString`. The server-level connection string does not include a database name.
+- **DocumentDBDatabaseResource** -- A child resource that represents a specific database on the server. Its connection string includes the database name in the path. This is what services typically reference with `WithReference()`.
+
+## Chaining Methods
+
+All configuration methods return the builder, so they can be chained:
+
+```csharp
+var db = builder.AddDocumentDB("documentdb")
+                .WithHostPort(10260)
+                .WithDataVolume()
+                .UseTls(true)
+                .AllowInsecureTls(true)
+                .AddDatabase("mydb");
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ This guide walks you through adding [DocumentDB](https://github.com/documentdb/d
 
 | Requirement | Details |
 |---|---|
-| .NET 9 SDK or later | [Download](https://dotnet.microsoft.com/download) |
+| .NET 10 SDK or later | [Download](https://dotnet.microsoft.com/download) |
 | .NET Aspire workload | `dotnet workload install aspire` |
 | Docker | DocumentDB runs as a Linux container. [Docker Desktop](https://www.docker.com/products/docker-desktop/) or any Docker-compatible runtime works. |
 | IDE (optional) | Visual Studio 2022 17.9+, VS Code with C# Dev Kit, or JetBrains Rider |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,7 +110,7 @@ You can find the generated connection string in the Aspire dashboard under the r
 
 - **TLS is enabled by default.** The DocumentDB container uses a self-signed certificate. The extension automatically adds `tls=true&tlsInsecure=true` to the connection string so the .NET MongoDB driver accepts the self-signed certificate.
 - **Credentials are auto-generated.** Unless you provide explicit parameters, the extension generates a random password and uses `admin` as the default username.
-- **Data is ephemeral.** By default, data is stored inside the container. When the container stops, data is lost. Use `WithDataVolume()` or `WithDataBindMount()` to persist data across restarts. See [Configuration](configuration.md) for details.
+- **Data is ephemeral.** By default, DocumentDB stores data inside the container. When the container stops, you lose that data. Use `WithDataVolume()` or `WithDataBindMount()` to persist data across restarts. See [Configuration](configuration.md) for details.
 
 ## Next steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,115 @@
+# Getting Started
+
+This guide walks you through adding [DocumentDB](https://github.com/documentdb/documentdb) to a .NET Aspire application. By the end, you will have a running Aspire app with a DocumentDB container that your services can connect to using the MongoDB driver.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| .NET 9 SDK or later | [Download](https://dotnet.microsoft.com/download) |
+| .NET Aspire workload | `dotnet workload install aspire` |
+| Docker | DocumentDB runs as a Linux container. [Docker Desktop](https://www.docker.com/products/docker-desktop/) or any Docker-compatible runtime works. |
+| IDE (optional) | Visual Studio 2022 17.9+, VS Code with C# Dev Kit, or JetBrains Rider |
+
+## 1. Create or open an Aspire project
+
+If you already have an Aspire project, skip to step 2.
+
+```bash
+dotnet new aspire-starter -n MyApp
+cd MyApp
+```
+
+This creates a solution with an AppHost project and a service project.
+
+## 2. Install the package
+
+In your **AppHost** project, add the DocumentDB hosting package:
+
+```bash
+cd MyApp.AppHost
+dotnet add package Aspire.Hosting.DocumentDB
+```
+
+## 3. Configure the AppHost
+
+In your AppHost's `Program.cs`, add a DocumentDB server and a database:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Add a DocumentDB server with a database
+var db = builder.AddDocumentDB("documentdb")
+                .AddDatabase("mydb");
+
+// Wire the database into your service
+var api = builder.AddProject<Projects.MyApp_ApiService>()
+                 .WithReference(db)
+                 .WaitFor(db);
+
+builder.Build().Run();
+```
+
+This tells Aspire to:
+
+1. Pull and start the `documentdb-local` container image
+2. Generate credentials and a connection string
+3. Pass the connection string to your service as a named connection
+
+## 4. Install the MongoDB client package
+
+In your **service** project (e.g. `MyApp.ApiService`), add the Aspire MongoDB driver integration:
+
+```bash
+cd MyApp.ApiService
+dotnet add package Aspire.MongoDB.Driver
+```
+
+## 5. Register and use the MongoDB client
+
+In your service's `Program.cs`, register the client using the same connection name you used in the AppHost:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Register the MongoDB client -- the connection name must match the AppHost resource name
+builder.AddMongoDBClient("mydb");
+```
+
+Then inject `IMongoClient` or `IMongoDatabase` in your services:
+
+```csharp
+app.MapGet("/documents", async (IMongoClient client) =>
+{
+    var database = client.GetDatabase("mydb");
+    var collection = database.GetCollection<BsonDocument>("items");
+    var docs = await collection.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+    return docs;
+});
+```
+
+## 6. Run the application
+
+```bash
+cd MyApp.AppHost
+dotnet run
+```
+
+Aspire will:
+
+- Start the DocumentDB container (first run pulls the image, which may take a minute)
+- Open the Aspire dashboard in your browser
+- Show the DocumentDB resource with its connection string, status, and logs
+
+You can find the generated connection string in the Aspire dashboard under the resource details.
+
+## What to expect
+
+- **TLS is enabled by default.** The DocumentDB container uses a self-signed certificate. The extension automatically adds `tls=true&tlsInsecure=true` to the connection string so the .NET MongoDB driver accepts the self-signed certificate.
+- **Credentials are auto-generated.** Unless you provide explicit parameters, the extension generates a random password and uses `admin` as the default username.
+- **Data is ephemeral.** By default, data is stored inside the container. When the container stops, data is lost. Use `WithDataVolume()` or `WithDataBindMount()` to persist data across restarts. See [Configuration](configuration.md) for details.
+
+## Next steps
+
+- [Configuration Reference](configuration.md) -- all available methods and options
+- [Troubleshooting](troubleshooting.md) -- common issues and solutions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,10 +13,10 @@ This guide walks you through adding [DocumentDB](https://github.com/documentdb/d
 
 ## Create or open an Aspire project
 
-If you already have an Aspire project, skip to step 2.
+If you already have an Aspire project, skip to [Install the package](#install-the-package).
 
 ```bash
-dotnet new aspire-starter -n MyApp
+dotnet new aspire-starter -o MyApp
 cd MyApp
 ```
 
@@ -43,7 +43,7 @@ var db = builder.AddDocumentDB("documentdb")
                 .AddDatabase("mydb");
 
 // Wire the database into your service
-var api = builder.AddProject<Projects.MyApp_ApiService>()
+var api = builder.AddProject<Projects.MyApp_ApiService>("apiservice")
                  .WithReference(db)
                  .WaitFor(db);
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,9 @@ This tells Aspire to:
 2. Generate credentials and a connection string
 3. Pass the connection string to your service as a named connection
 
+> [!NOTE]
+> `WaitFor` sequences container startup but does not perform a readiness health check. Your service should handle transient connection failures with retry logic during the first few seconds while DocumentDB initializes.
+
 ## Install the MongoDB client package
 
 In your **service** project (for example, `MyApp.ApiService`), add the Aspire MongoDB driver integration:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Getting started
 
 This guide walks you through adding [DocumentDB](https://github.com/documentdb/documentdb) to a .NET Aspire application. By the end, you will have a running Aspire app with a DocumentDB container that your services can connect to using the MongoDB driver.
 
@@ -11,7 +11,7 @@ This guide walks you through adding [DocumentDB](https://github.com/documentdb/d
 | Docker | DocumentDB runs as a Linux container. [Docker Desktop](https://www.docker.com/products/docker-desktop/) or any Docker-compatible runtime works. |
 | IDE (optional) | Visual Studio 2022 17.9+, VS Code with C# Dev Kit, or JetBrains Rider |
 
-## 1. Create or open an Aspire project
+## Create or open an Aspire project
 
 If you already have an Aspire project, skip to step 2.
 
@@ -22,7 +22,7 @@ cd MyApp
 
 This creates a solution with an AppHost project and a service project.
 
-## 2. Install the package
+## Install the package
 
 In your **AppHost** project, add the DocumentDB hosting package:
 
@@ -31,7 +31,7 @@ cd MyApp.AppHost
 dotnet add package Aspire.Hosting.DocumentDB
 ```
 
-## 3. Configure the AppHost
+## Configure the AppHost
 
 In your AppHost's `Program.cs`, add a DocumentDB server and a database:
 
@@ -56,16 +56,16 @@ This tells Aspire to:
 2. Generate credentials and a connection string
 3. Pass the connection string to your service as a named connection
 
-## 4. Install the MongoDB client package
+## Install the MongoDB client package
 
-In your **service** project (e.g. `MyApp.ApiService`), add the Aspire MongoDB driver integration:
+In your **service** project (for example, `MyApp.ApiService`), add the Aspire MongoDB driver integration:
 
 ```bash
 cd MyApp.ApiService
 dotnet add package Aspire.MongoDB.Driver
 ```
 
-## 5. Register and use the MongoDB client
+## Register and use the MongoDB client
 
 In your service's `Program.cs`, register the client using the same connection name you used in the AppHost:
 
@@ -88,7 +88,7 @@ app.MapGet("/documents", async (IMongoClient client) =>
 });
 ```
 
-## 6. Run the application
+## Run the application
 
 ```bash
 cd MyApp.AppHost
@@ -111,5 +111,5 @@ You can find the generated connection string in the Aspire dashboard under the r
 
 ## Next steps
 
-- [Configuration Reference](configuration.md) -- all available methods and options
-- [Troubleshooting](troubleshooting.md) -- common issues and solutions
+- [Configuration reference](configuration.md) — all available methods and options
+- [Troubleshooting](troubleshooting.md) — common issues and solutions

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,7 +66,7 @@ Common causes:
 **Symptom:** `MongoConnectionException` with "connection refused" or timeout.
 
 **Causes and solutions:**
-1. **Container not ready yet.** DocumentDB takes a few seconds to initialize. Use `.WaitFor(db)` in your AppHost to ensure the service waits for DocumentDB to be healthy before starting.
+1. **Container not ready yet.** DocumentDB takes a few seconds to initialize. Use `.WaitFor(db)` in your AppHost to improve startup ordering, but note that this integration does not currently register health checks, so your service should still handle transient connection failures with retry/backoff until DocumentDB is ready.
 2. **Wrong port.** By default, Aspire assigns a random host port. Do not hardcode ports in your service -- use `WithReference()` to inject the connection string automatically.
 3. **Firewall or network issue.** If running Docker in a VM or WSL2, ensure port forwarding is configured.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,179 @@
+# Troubleshooting
+
+Common issues when using `Aspire.Hosting.DocumentDB` and how to resolve them.
+
+## Docker issues
+
+### Docker is not running
+
+**Symptom:** The DocumentDB resource fails to start with an error about the Docker daemon.
+
+**Solution:** Start Docker Desktop or your Docker daemon. Aspire requires a running Docker runtime to start container resources.
+
+```bash
+# Verify Docker is running
+docker info
+```
+
+### Container image pull fails
+
+**Symptom:** Timeout or network error pulling `ghcr.io/documentdb/documentdb/documentdb-local`.
+
+**Solution:**
+1. Verify network connectivity: `docker pull ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.109.0`
+2. Check if you need to authenticate to GitHub Container Registry (public images should not require auth)
+3. If behind a corporate proxy, configure Docker's proxy settings
+
+### Container fails to start
+
+**Symptom:** The resource shows as "Failed" in the Aspire dashboard.
+
+**Solution:** Check the container logs in the Aspire dashboard or via Docker:
+
+```bash
+# Find the container
+docker ps -a | grep documentdb
+
+# View logs
+docker logs <container-id>
+```
+
+Common causes:
+- Port already in use (see [Port conflicts](#port-conflicts) below)
+- Insufficient Docker resources (memory, disk)
+- Corrupted data volume (remove the volume and restart)
+
+## Connection issues
+
+### TLS certificate errors
+
+**Symptom:** `MongoAuthenticationException` or `SslPolicyErrors.RemoteCertificateChainErrors` when connecting from your service.
+
+**Cause:** The DocumentDB container uses a self-signed TLS certificate. The .NET MongoDB driver rejects it unless `tlsInsecure=true` is in the connection string.
+
+**Solution:** This should work automatically. The extension adds `tls=true&tlsInsecure=true` to the connection string by default. If you see this error:
+
+1. Verify you are referencing the resource correctly: `.WithReference(db)` where `db` is the database resource from `AddDatabase()`.
+2. If you manually constructed a connection string, add `tlsInsecure=true` (not `tlsAllowInvalidCertificates=true` -- the .NET driver does not fully honor the latter for self-signed certificates).
+3. If connecting from a tool outside of Aspire, use this format:
+   ```
+   mongodb://admin:<password>@localhost:<port>/?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true
+   ```
+
+### Connection refused / timeout
+
+**Symptom:** `MongoConnectionException` with "connection refused" or timeout.
+
+**Causes and solutions:**
+1. **Container not ready yet.** DocumentDB takes a few seconds to initialize. Use `.WaitFor(db)` in your AppHost to ensure the service waits for DocumentDB to be healthy before starting.
+2. **Wrong port.** By default, Aspire assigns a random host port. Do not hardcode ports in your service -- use `WithReference()` to inject the connection string automatically.
+3. **Firewall or network issue.** If running Docker in a VM or WSL2, ensure port forwarding is configured.
+
+### Authentication failures
+
+**Symptom:** `MongoAuthenticationException: Unable to authenticate`.
+
+**Causes and solutions:**
+1. **Wrong credentials.** The extension generates a random password on each run (unless you provide fixed parameters). Always use the Aspire-injected connection string rather than hardcoding credentials.
+2. **Auth mechanism mismatch.** DocumentDB uses `SCRAM-SHA-256`. The connection string includes `authMechanism=SCRAM-SHA-256` automatically. If you construct your own connection string, include this parameter.
+3. **Auth database.** Credentials are created in the `admin` database. The connection string includes `authSource=admin` automatically.
+
+## Port conflicts
+
+**Symptom:** `Bind for 0.0.0.0:10260 failed: port is already allocated`.
+
+**Solution:**
+1. By default, Aspire uses a random port, so this only happens if you used `WithHostPort(10260)` or `port: 10260`.
+2. Either remove the fixed port to let Aspire pick a random one, or stop whatever is using port 10260:
+   ```bash
+   # Find what's using the port
+   lsof -i :10260   # macOS/Linux
+   netstat -ano | findstr :10260   # Windows
+   ```
+
+## Data persistence
+
+### Data lost after container restart
+
+**Symptom:** All documents disappear when the Aspire application or Docker restarts.
+
+**Cause:** By default, DocumentDB data is stored inside the container filesystem, which is ephemeral.
+
+**Solution:** Use `WithDataVolume()` to persist data in a Docker named volume:
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithDataVolume();
+```
+
+Or use `WithDataBindMount()` to persist data to a specific host directory:
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithDataBindMount("./data/documentdb");
+```
+
+### Corrupted data volume
+
+**Symptom:** Container fails to start with errors about `PG_VERSION` or data directory corruption.
+
+**Solution:** Remove the existing volume and let DocumentDB recreate it:
+
+```bash
+# Find and remove the volume
+docker volume ls | grep documentdb
+docker volume rm <volume-name>
+```
+
+## Debugging with mongosh
+
+You can connect to the running DocumentDB container directly using `mongosh` for debugging:
+
+```bash
+# Find the allocated port from the Aspire dashboard, or:
+docker ps | grep documentdb
+
+# Connect with mongosh
+mongosh "mongodb://admin:<password>@localhost:<port>/?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+```
+
+Replace `<password>` and `<port>` with the values from the Aspire dashboard (click on the resource to see its connection string).
+
+Useful mongosh commands:
+
+```javascript
+// List databases
+show dbs
+
+// Switch to your database
+use mydb
+
+// List collections
+show collections
+
+// Find documents
+db.mycollection.find()
+
+// Check server status
+db.runCommand({ ping: 1 })
+```
+
+## Viewing container logs
+
+DocumentDB container logs can help diagnose startup and runtime issues:
+
+1. **Aspire Dashboard:** Click on the DocumentDB resource and switch to the "Logs" tab.
+2. **Docker CLI:**
+   ```bash
+   docker ps | grep documentdb
+   docker logs <container-id>
+
+   # Follow logs in real-time
+   docker logs -f <container-id>
+   ```
+
+## Known Limitations
+
+- **Health checks are not enabled by default.** The health check integration is present in the code but commented out. Use `.WaitFor()` to sequence resource startup.
+- **No built-in backup/restore.** For development data, use `WithDataVolume()` for persistence. For important data, use `mongodump` / `mongorestore` manually.
+- **Single server only.** The extension does not support replica sets or sharded clusters. It runs a single DocumentDB container intended for local development.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,6 +95,26 @@ Common causes:
    netstat -ano | findstr :10260   # Windows
    ```
 
+## Wrong resource reference
+
+**Symptom:** MongoDB operations fail with errors about missing database name, or data is written to an unexpected database.
+
+**Cause:** You are referencing the *server* resource instead of the *database* resource. The server connection string does not include a database name in the path.
+
+**Solution:** Always reference the database resource returned by `AddDatabase()`:
+
+```csharp
+var server = builder.AddDocumentDB("documentdb");
+var db = server.AddDatabase("mydb");
+
+builder.AddProject<Projects.MyService>("myservice")
+       // Correct -- connection string includes /mydb
+       .WithReference(db);
+
+       // Wrong -- connection string has no database name
+       // .WithReference(server);
+```
+
 ## Data persistence
 
 ### Data lost after container restart

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -164,7 +164,7 @@ mongosh "mongodb://admin:<password>@localhost:<port>/?authSource=admin&authMecha
 Replace `<password>` and `<port>` with the values from the Aspire dashboard (click on the resource to see its connection string).
 For `mongosh`, `tlsAllowInvalidCertificates=true` matches the upstream DocumentDB documentation. For .NET applications, use the Aspire-generated connection string, which uses `tlsInsecure=true`.
 
-Useful mongosh commands:
+### Useful `mongosh` commands
 
 ```javascript
 // List databases
@@ -199,6 +199,6 @@ DocumentDB container logs can help diagnose startup and runtime issues:
 
 ## Known limitations
 
-- **Health checks are not enabled by default.** The health check integration is present in the code but commented out. Use `.WaitFor()` to sequence resource startup.
+- **Health checks are not enabled by default.** This integration does not currently register health checks. Use `.WaitFor()` to sequence resource startup.
 - **No built-in backup/restore.** For development data, use `WithDataVolume()` for persistence. For important data, use `mongodump` / `mongorestore` manually.
 - **Single server only.** The extension does not support replica sets or sharded clusters. It runs a single DocumentDB container intended for local development.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ Common causes:
 **Solution:** This should work automatically. The extension adds `tls=true&tlsInsecure=true` to the connection string by default. If you see this error:
 
 1. Verify you are referencing the resource correctly: `.WithReference(db)` where `db` is the database resource from `AddDatabase()`.
-2. If you manually constructed a connection string, add `tlsInsecure=true` (not `tlsAllowInvalidCertificates=true` -- the .NET driver does not fully honor the latter for self-signed certificates).
+2. If you manually constructed a connection string, add `tlsInsecure=true` (not `tlsAllowInvalidCertificates=true` — the .NET driver does not fully honor the latter for self-signed certificates).
 3. If connecting from `mongosh` or another MongoDB CLI tool outside of Aspire, use this format:
    ```
    mongodb://admin:<password>@localhost:<port>/?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true
@@ -66,8 +66,11 @@ Common causes:
 **Symptom:** `MongoConnectionException` with "connection refused" or timeout.
 
 **Causes and solutions:**
-1. **Container not ready yet.** DocumentDB takes a few seconds to initialize. Use `.WaitFor(db)` in your AppHost to improve startup ordering, but note that this integration does not currently register health checks, so your service should still handle transient connection failures with retry/backoff until DocumentDB is ready.
-2. **Wrong port.** By default, Aspire assigns a random host port. Do not hardcode ports in your service -- use `WithReference()` to inject the connection string automatically.
+1. **Container not ready yet.** DocumentDB takes a few seconds to initialize. Use `.WaitFor(db)` in your AppHost to improve startup ordering.
+
+> [!IMPORTANT]
+> This integration does not currently register health checks. Your service should handle transient connection failures with retry/backoff until DocumentDB is ready.
+2. **Wrong port.** By default, Aspire assigns a random host port. Do not hardcode ports in your service — use `WithReference()` to inject the connection string automatically.
 3. **Firewall or network issue.** If running Docker in a VM or WSL2, ensure port forwarding is configured.
 
 ### Authentication failures
@@ -98,7 +101,7 @@ Common causes:
 
 **Symptom:** All documents disappear when the Aspire application or Docker restarts.
 
-**Cause:** By default, DocumentDB data is stored inside the container filesystem, which is ephemeral.
+**Cause:** By default, DocumentDB stores data inside the container filesystem. This storage is ephemeral.
 
 **Solution:** Use `WithDataVolume()` to persist data in a Docker named volume:
 
@@ -174,7 +177,7 @@ DocumentDB container logs can help diagnose startup and runtime issues:
    docker logs -f <container-id>
    ```
 
-## Known Limitations
+## Known limitations
 
 - **Health checks are not enabled by default.** The health check integration is present in the code but commented out. Use `.WaitFor()` to sequence resource startup.
 - **No built-in backup/restore.** For development data, use `WithDataVolume()` for persistence. For important data, use `mongodump` / `mongorestore` manually.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,10 +55,11 @@ Common causes:
 
 1. Verify you are referencing the resource correctly: `.WithReference(db)` where `db` is the database resource from `AddDatabase()`.
 2. If you manually constructed a connection string, add `tlsInsecure=true` (not `tlsAllowInvalidCertificates=true` -- the .NET driver does not fully honor the latter for self-signed certificates).
-3. If connecting from a tool outside of Aspire, use this format:
+3. If connecting from `mongosh` or another MongoDB CLI tool outside of Aspire, use this format:
    ```
    mongodb://admin:<password>@localhost:<port>/?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true
    ```
+   `mongosh` accepts `tlsAllowInvalidCertificates=true`. For .NET applications, prefer `tlsInsecure=true`.
 
 ### Connection refused / timeout
 
@@ -138,6 +139,7 @@ mongosh "mongodb://admin:<password>@localhost:<port>/?authSource=admin&authMecha
 ```
 
 Replace `<password>` and `<port>` with the values from the Aspire dashboard (click on the resource to see its connection string).
+For `mongosh`, `tlsAllowInvalidCertificates=true` matches the upstream DocumentDB documentation. For .NET applications, use the Aspire-generated connection string, which uses `tlsInsecure=true`.
 
 Useful mongosh commands:
 

--- a/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
+++ b/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
@@ -18,7 +18,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>AzureCosmosDB_256x.png</PackageIcon>
-    <PackageReadmeFile>src/Aspire.Hosting.DocumentDB/README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <None Include="$(SharedDir)AzureCosmosDB_256x.png" Pack="true" PackagePath="\" />
-    <None Include="README.md" Pack="true" PackagePath="src/Aspire.Hosting.DocumentDB/" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="../../CHANGELOG.md" Pack="true" PackagePath="\" />
     <None Include="../../LICENSE" Pack="true" PackagePath="\" />
     <None Include="../../docs/**/*.md" Pack="true" PackagePath="docs/%(RecursiveDir)%(Filename)%(Extension)" />

--- a/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
+++ b/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
@@ -18,7 +18,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>AzureCosmosDB_256x.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>src/Aspire.Hosting.DocumentDB/README.md</PackageReadmeFile>
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
@@ -32,7 +32,10 @@
 
   <ItemGroup>
     <None Include="$(SharedDir)AzureCosmosDB_256x.png" Pack="true" PackagePath="\" />
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="src/Aspire.Hosting.DocumentDB/" />
+    <None Include="../../CHANGELOG.md" Pack="true" PackagePath="\" />
+    <None Include="../../LICENSE" Pack="true" PackagePath="\" />
+    <None Include="../../docs/**/*.md" Pack="true" PackagePath="docs/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -275,7 +275,7 @@ public static class DocumentDBBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <example>
     /// <code>
-    /// // Require valid certificates (e.g., production with real certs):
+    /// // Require valid certificates (for example, production with real certs):
     /// var server = builder.AddDocumentDB("documentdb")
     ///                     .AllowInsecureTls(false);
     /// </code>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -29,6 +29,11 @@ public static class DocumentDBBuilderExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="port">The host port for DocumentDB.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// var server = builder.AddDocumentDB("documentdb", port: 10260);
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> AddDocumentDB(this IDistributedApplicationBuilder builder, [ResourceName] string name, int? port)
     {
         return AddDocumentDB(builder, name, port, null, null);
@@ -43,6 +48,17 @@ public static class DocumentDBBuilderExtensions
     /// <param name="userName">A parameter that contains the DocumentDB server user name, or <see langword="null"/> to use a default value.</param>
     /// <param name="password">A parameter that contains the DocumentDB server password, or <see langword="null"/> to use a generated password.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// // Minimal usage with generated credentials:
+    /// var db = builder.AddDocumentDB("documentdb").AddDatabase("mydb");
+    ///
+    /// // With custom credentials:
+    /// var user = builder.AddParameter("db-user");
+    /// var pass = builder.AddParameter("db-pass", secret: true);
+    /// var db = builder.AddDocumentDB("documentdb", userName: user, password: pass);
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> AddDocumentDB(this IDistributedApplicationBuilder builder,
         string name,
         int? port = null,
@@ -80,10 +96,21 @@ public static class DocumentDBBuilderExtensions
     /// <summary>
     /// Adds a DocumentDB database to the application model.
     /// </summary>
+    /// <remarks>
+    /// The database resource inherits the parent server's connection string and appends the database name.
+    /// Services should reference the database resource (not the server) via <c>.WithReference(db)</c>.
+    /// </remarks>
     /// <param name="builder">The DocumentDB server resource builder.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="databaseName">The name of the database. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// var server = builder.AddDocumentDB("documentdb");
+    /// var ordersDb = server.AddDatabase("orders");
+    /// var usersDb = server.AddDatabase("users");
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBDatabaseResource> AddDatabase(this IResourceBuilder<DocumentDBServerResource> builder, [ResourceName] string name, string? databaseName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -123,6 +150,12 @@ public static class DocumentDBBuilderExtensions
     /// <param name="builder">The resource builder for DocumentDB.</param>
     /// <param name="port">The port to bind on the host. If <see langword="null"/> is used random port will be assigned.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// var server = builder.AddDocumentDB("documentdb")
+    ///                     .WithHostPort(10260);
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> WithHostPort(this IResourceBuilder<DocumentDBServerResource> builder, int? port)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -136,11 +169,21 @@ public static class DocumentDBBuilderExtensions
     /// <summary>
     /// Adds a named volume for the data folder to a DocumentDB container resource.
     /// </summary>
+    /// <remarks>
+    /// Without a volume, all data is stored inside the container and lost when it stops.
+    /// The <c>DATA_PATH</c> environment variable is set to <paramref name="targetPath"/> inside the container.
+    /// </remarks>
     /// <param name="builder">The resource builder.</param>
     /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <param name="targetPath">The target path inside the container. Defaults to /home/documentdb/postgresql/data.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// var server = builder.AddDocumentDB("documentdb")
+    ///                     .WithDataVolume();
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> WithDataVolume(
         this IResourceBuilder<DocumentDBServerResource> builder,
         string? name = null,
@@ -162,10 +205,21 @@ public static class DocumentDBBuilderExtensions
     /// <summary>
     /// Adds a bind mount for the data folder to a DocumentDB container resource.
     /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="WithDataVolume"/> for most cases. Bind mounts are useful when you need
+    /// direct access to the data files on the host filesystem.
+    /// The <c>DATA_PATH</c> environment variable is set inside the container.
+    /// </remarks>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// var server = builder.AddDocumentDB("documentdb")
+    ///                     .WithDataBindMount("./data/documentdb");
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> WithDataBindMount(this IResourceBuilder<DocumentDBServerResource> builder, string source, bool isReadOnly = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -189,6 +243,13 @@ public static class DocumentDBBuilderExtensions
     /// <param name="builder">The resource builder for DocumentDB.</param>
     /// <param name="useTls">Whether to enable TLS. Defaults to <see langword="true"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// // Disable TLS for a non-TLS endpoint:
+    /// var server = builder.AddDocumentDB("documentdb")
+    ///                     .UseTls(false);
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> UseTls(this IResourceBuilder<DocumentDBServerResource> builder, bool useTls = true)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -203,9 +264,21 @@ public static class DocumentDBBuilderExtensions
     /// certificate used by the DocumentDB Local container.
     /// Call <c>AllowInsecureTls(false)</c> to require valid certificates.
     /// </summary>
+    /// <remarks>
+    /// The extension uses <c>tlsInsecure=true</c> rather than <c>tlsAllowInvalidCertificates=true</c>
+    /// because the .NET MongoDB driver does not fully honor <c>tlsAllowInvalidCertificates</c> for
+    /// self-signed certificates and raises <c>UntrustedRoot</c> errors.
+    /// </remarks>
     /// <param name="builder">The resource builder for DocumentDB.</param>
     /// <param name="allowInsecureTls">Whether to allow insecure TLS. Defaults to <see langword="true"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// // Require valid certificates (e.g., production with real certs):
+    /// var server = builder.AddDocumentDB("documentdb")
+    ///                     .AllowInsecureTls(false);
+    /// </code>
+    /// </example>
     public static IResourceBuilder<DocumentDBServerResource> AllowInsecureTls(this IResourceBuilder<DocumentDBServerResource> builder, bool allowInsecureTls = true)
     {
         ArgumentNullException.ThrowIfNull(builder);

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -51,12 +51,13 @@ public static class DocumentDBBuilderExtensions
     /// <example>
     /// <code>
     /// // Minimal usage with generated credentials:
-    /// var db = builder.AddDocumentDB("documentdb").AddDatabase("mydb");
+    /// var server = builder.AddDocumentDB("documentdb");
+    /// var database = server.AddDatabase("mydb");
     ///
     /// // With custom credentials:
     /// var user = builder.AddParameter("db-user");
     /// var pass = builder.AddParameter("db-pass", secret: true);
-    /// var db = builder.AddDocumentDB("documentdb", userName: user, password: pass);
+    /// var securedServer = builder.AddDocumentDB("documentdb", userName: user, password: pass);
     /// </code>
     /// </example>
     public static IResourceBuilder<DocumentDBServerResource> AddDocumentDB(this IDistributedApplicationBuilder builder,

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class DocumentDBBuilderExtensions
 
     private const string UserEnvVarName = "USERNAME";
     private const string PasswordEnvVarName = "PASSWORD";
+    private const string DefaultMountedDataPath = "/home/documentdb/postgresql/data";
 
     /// <summary>
     /// Adds a DocumentDB resource to the application model. A container is used for local development.
@@ -172,12 +173,14 @@ public static class DocumentDBBuilderExtensions
     /// </summary>
     /// <remarks>
     /// Without a volume, all data is stored inside the container and lost when it stops.
-    /// The <c>DATA_PATH</c> environment variable is set to <paramref name="targetPath"/> inside the container.
+    /// The bare DocumentDB container defaults <c>DATA_PATH</c> to <c>/data</c>.
+    /// This helper mounts the volume at <paramref name="targetPath"/> and sets
+    /// <c>DATA_PATH</c> to the same value so DocumentDB writes to the mounted directory.
     /// </remarks>
     /// <param name="builder">The resource builder.</param>
     /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
-    /// <param name="targetPath">The target path inside the container. Defaults to /home/documentdb/postgresql/data.</param>
+    /// <param name="targetPath">The target path inside the container. Defaults to /home/documentdb/postgresql/data when this helper is used.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <example>
     /// <code>
@@ -193,7 +196,7 @@ public static class DocumentDBBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        targetPath ??= "/home/documentdb/postgresql/data";
+        targetPath ??= DefaultMountedDataPath;
 
         return builder
             .WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), targetPath, isReadOnly)
@@ -209,7 +212,9 @@ public static class DocumentDBBuilderExtensions
     /// <remarks>
     /// Prefer <see cref="WithDataVolume"/> for most cases. Bind mounts are useful when you need
     /// direct access to the data files on the host filesystem.
-    /// The <c>DATA_PATH</c> environment variable is set inside the container.
+    /// The bare DocumentDB container defaults <c>DATA_PATH</c> to <c>/data</c>.
+    /// This helper mounts the directory at <c>/home/documentdb/postgresql/data</c> and sets
+    /// <c>DATA_PATH</c> to the same value so DocumentDB writes to the mounted directory.
     /// </remarks>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
@@ -226,7 +231,7 @@ public static class DocumentDBBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        const string targetPath = "/home/documentdb/postgresql/data";
+        const string targetPath = DefaultMountedDataPath;
 
         return builder
             .WithBindMount(source, targetPath, isReadOnly)

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -1,87 +1,107 @@
-# Aspire.Hosting.DocumentDB library
+# Aspire.Hosting.DocumentDB
 
-[DocumentDB](https://github.com/documentdb/documentdb) is a MongoDB compatible open source document database built on PostgreSQL. This provides extension methods and resource definitions for a .NET Aspire AppHost to configure a DocumentDB resource.
+[DocumentDB](https://github.com/documentdb/documentdb) is an open-source, MongoDB-compatible document database built on PostgreSQL. This package provides .NET Aspire hosting integration to configure and run a DocumentDB container as part of your distributed application.
 
-## Getting started
+## Getting Started
+
+### Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download) or later with the Aspire workload: `dotnet workload install aspire`
+- [Docker](https://www.docker.com/products/docker-desktop/) (DocumentDB runs as a Linux container)
 
 ### Install the package
 
-In your AppHost project, install the .NET Aspire DocumentDB Hosting library with [NuGet](https://www.nuget.org):
+In your AppHost project:
 
 ```dotnetcli
 dotnet add package Aspire.Hosting.DocumentDB
 ```
 
-## Usage example
+### Add a DocumentDB resource
 
-Then, in the _AppHost.cs_ file of `AppHost`, add a DocumentDB resource and consume the connection using the following methods:
+In the AppHost `Program.cs`:
 
 ```csharp
-var db = builder.AddDocumentDB("DocumentDB").AddDatabase("mydb");
+var builder = DistributedApplication.CreateBuilder(args);
 
-var myService = builder.AddProject<Projects.MyService>()
-                       .WithReference(db);
+var db = builder.AddDocumentDB("documentdb")
+                .AddDatabase("mydb");
+
+builder.AddProject<Projects.MyService>()
+       .WithReference(db)
+       .WaitFor(db);
+
+builder.Build().Run();
 ```
 
-For local development, the generated DocumentDB connection strings enable TLS and allow the self-signed local certificate automatically so client applications can connect without extra manual connection string settings.
+### Connect from your service
 
-## Connecting from client applications
-
-To connect to DocumentDB from your application services, you'll need to install the MongoDB client integration package:
-
-### Install the client package
-
-In your service project, install the .NET Aspire MongoDB Driver component with [NuGet](https://www.nuget.org):
+In your service project, install the Aspire MongoDB driver integration:
 
 ```dotnetcli
 dotnet add package Aspire.MongoDB.Driver
 ```
 
-### Register the MongoDB client
-
-In your service's `Program.cs` file, register the MongoDB client:
+Register the client in `Program.cs`:
 
 ```csharp
-builder.AddMongoDBClient("DocumentDB");
+builder.AddMongoDBClient("mydb");
 ```
 
-### Use the MongoDB client
-
-Inject and use the MongoDB client in your services:
+Inject and use the MongoDB client:
 
 ```csharp
-public class MyService
+public class MyService(IMongoClient mongoClient)
 {
-    private readonly IMongoDatabase _database;
+    private readonly IMongoDatabase _database = mongoClient.GetDatabase("mydb");
 
-    public MyService(IMongoClient mongoClient)
+    public async Task<List<BsonDocument>> GetDocumentsAsync()
     {
-        _database = mongoClient.GetDatabase("mydb");
+        var collection = _database.GetCollection<BsonDocument>("mycollection");
+        return await collection.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
     }
-
-    public async Task<List<MyDocument>> GetDocumentsAsync()
-    {
-        var collection = _database.GetCollection<MyDocument>("mycollection");
-        return await collection.Find(FilterDefinition<MyDocument>.Empty).ToListAsync();
-    }
-
-    public async Task InsertDocumentAsync(MyDocument document)
-    {
-        var collection = _database.GetCollection<MyDocument>("mycollection");
-        await collection.InsertOneAsync(document);
-    }
-}
-
-public class MyDocument
-{
-    public ObjectId Id { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
 }
 ```
 
-The client integration handles connection string resolution and provides features like health checks, logging, and telemetry automatically.
+The Aspire integration handles connection string resolution, TLS configuration, and credential management automatically.
 
-## Feedback & contributing
+## Configuration
 
-https://github.com/dotnet/aspire
+| Method | Description |
+|---|---|
+| `AddDocumentDB(name, port?, userName?, password?)` | Add a DocumentDB server container |
+| `.AddDatabase(name, databaseName?)` | Add a named database |
+| `.WithHostPort(port)` | Bind to a fixed host port (default: random) |
+| `.WithDataVolume(name?)` | Persist data with a Docker volume |
+| `.WithDataBindMount(source)` | Persist data with a host directory mount |
+| `.UseTls(useTls?)` | Enable/disable TLS (default: enabled) |
+| `.AllowInsecureTls(allow?)` | Allow self-signed certs (default: enabled) |
+
+### Connection strings
+
+The extension generates MongoDB connection strings automatically:
+
+```
+mongodb://admin:<password>@<host>:<port>/<database>?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true
+```
+
+TLS and insecure TLS are enabled by default so the .NET MongoDB driver can connect to the self-signed certificate used by the DocumentDB Local container.
+
+### Data persistence
+
+By default, data is stored inside the container and lost on restart. Use `WithDataVolume()` to persist:
+
+```csharp
+builder.AddDocumentDB("documentdb")
+       .WithDataVolume()
+       .AddDatabase("mydb");
+```
+
+## More information
+
+- [Getting started guide](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/getting-started.md) -- detailed step-by-step setup
+- [Configuration reference](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md) -- all methods, parameters, defaults, and connection string details
+- [Troubleshooting](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/troubleshooting.md) -- TLS errors, Docker issues, connection failures, debugging
+- [Changelog](https://github.com/microsoft/azure-databases-aspire/blob/main/CHANGELOG.md) -- release history
+- [DocumentDB project](https://github.com/documentdb/documentdb) -- the database itself
+- [.NET Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) -- Aspire framework docs

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -27,7 +27,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var db = builder.AddDocumentDB("documentdb")
                 .AddDatabase("mydb");
 
-builder.AddProject<Projects.MyService>()
+builder.AddProject<Projects.MyService>("myservice")
        .WithReference(db)
        .WaitFor(db);
 

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -6,7 +6,7 @@
 
 ### Prerequisites
 
-- [.NET 9 SDK](https://dotnet.microsoft.com/download) or later with the Aspire workload: `dotnet workload install aspire`
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) or later with the Aspire workload: `dotnet workload install aspire`
 - [Docker](https://www.docker.com/products/docker-desktop/) (DocumentDB runs as a Linux container)
 
 ### Install the package

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -2,7 +2,7 @@
 
 [DocumentDB](https://github.com/documentdb/documentdb) is an open-source, MongoDB-compatible document database built on PostgreSQL. This package provides .NET Aspire hosting integration to configure and run a DocumentDB container as part of your distributed application.
 
-## Getting Started
+## Getting started
 
 ### Prerequisites
 
@@ -99,9 +99,9 @@ builder.AddDocumentDB("documentdb")
 
 ## More information
 
-- [Getting started guide](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/getting-started.md) -- detailed step-by-step setup
-- [Configuration reference](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md) -- all methods, parameters, defaults, and connection string details
-- [Troubleshooting](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/troubleshooting.md) -- TLS errors, Docker issues, connection failures, debugging
-- [Changelog](https://github.com/microsoft/azure-databases-aspire/blob/main/CHANGELOG.md) -- release history
-- [DocumentDB project](https://github.com/documentdb/documentdb) -- the database itself
-- [.NET Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) -- Aspire framework docs
+- [Getting started guide](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/getting-started.md) — detailed step-by-step setup
+- [Configuration reference](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md) — all methods, parameters, defaults, and connection string details
+- [Troubleshooting](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/troubleshooting.md) — TLS errors, Docker issues, connection failures, debugging
+- [Changelog](https://github.com/microsoft/azure-databases-aspire/blob/main/CHANGELOG.md) — release history
+- [DocumentDB project](https://github.com/documentdb/documentdb) — the database itself
+- [.NET Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) — Aspire framework docs

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -82,7 +82,7 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 The extension generates MongoDB connection strings automatically:
 
 ```
-mongodb://admin:<password>@<host>:<port>/<database>?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true
+mongodb://admin:<password>@<host>:<port>[/<database>]?authSource=admin&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true
 ```
 
 TLS and insecure TLS are enabled by default so the .NET MongoDB driver can connect to the self-signed certificate used by the DocumentDB Local container.

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -99,9 +99,10 @@ builder.AddDocumentDB("documentdb")
 
 ## More information
 
-- [Getting started guide](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/getting-started.md) — detailed step-by-step setup
-- [Configuration reference](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md) — all methods, parameters, defaults, and connection string details
-- [Troubleshooting](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/troubleshooting.md) — TLS errors, Docker issues, connection failures, debugging
-- [Changelog](https://github.com/microsoft/azure-databases-aspire/blob/main/CHANGELOG.md) — release history
+- [Getting started guide](../../docs/getting-started.md) — detailed step-by-step setup
+- [Configuration reference](../../docs/configuration.md) — all methods, parameters, defaults, and connection string details
+- [Troubleshooting](../../docs/troubleshooting.md) — TLS errors, Docker issues, connection failures, debugging
+- [Changelog](../../CHANGELOG.md) — release history
+- [License](../../LICENSE) — package license
 - [DocumentDB project](https://github.com/documentdb/documentdb) — the database itself
 - [.NET Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) — Aspire framework docs

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -72,8 +72,8 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 | `AddDocumentDB(name, port?, userName?, password?)` | Add a DocumentDB server container |
 | `.AddDatabase(name, databaseName?)` | Add a named database |
 | `.WithHostPort(port)` | Bind to a fixed host port (default: random) |
-| `.WithDataVolume(name?)` | Persist data with a Docker volume |
-| `.WithDataBindMount(source)` | Persist data with a host directory mount |
+| `.WithDataVolume(name?, isReadOnly?, targetPath?)` | Persist data with a Docker volume |
+| `.WithDataBindMount(source, isReadOnly?)` | Persist data with a host directory mount |
 | `.UseTls(useTls?)` | Enable/disable TLS (default: enabled) |
 | `.AllowInsecureTls(allow?)` | Allow self-signed certs (default: enabled) |
 

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -89,7 +89,7 @@ TLS and insecure TLS are enabled by default so the .NET MongoDB driver can conne
 
 ### Data persistence
 
-By default, data is stored inside the container and lost on restart. Use `WithDataVolume()` to persist:
+By default, DocumentDB stores data inside the container, and restarting the container removes it. Use `WithDataVolume()` to persist it:
 
 ```csharp
 builder.AddDocumentDB("documentdb")
@@ -99,10 +99,10 @@ builder.AddDocumentDB("documentdb")
 
 ## More information
 
-- [Getting started guide](../../docs/getting-started.md) — detailed step-by-step setup
-- [Configuration reference](../../docs/configuration.md) — all methods, parameters, defaults, and connection string details
-- [Troubleshooting](../../docs/troubleshooting.md) — TLS errors, Docker issues, connection failures, debugging
-- [Changelog](../../CHANGELOG.md) — release history
-- [License](../../LICENSE) — package license
+- [Getting started guide](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/getting-started.md) — detailed step-by-step setup
+- [Configuration reference](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md) — all methods, parameters, defaults, and connection string details
+- [Troubleshooting](https://github.com/microsoft/azure-databases-aspire/blob/main/docs/troubleshooting.md) — TLS errors, Docker issues, connection failures, debugging
+- [Changelog](https://github.com/microsoft/azure-databases-aspire/blob/main/CHANGELOG.md) — release history
+- [License](https://github.com/microsoft/azure-databases-aspire/blob/main/LICENSE) — package license
 - [DocumentDB project](https://github.com/documentdb/documentdb) — the database itself
 - [.NET Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) — Aspire framework docs

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -10,7 +10,9 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataBindMount(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string source, bool isReadOnly = false) { throw null; }
 
-        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataVolume(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string? name = null, bool isReadOnly = false) { throw null; }
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataVolume(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string? name = null, bool isReadOnly = false, string? targetPath = null) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithHostPort(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, int? port) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> UseTls(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool useTls = true) { throw null; }
 

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -70,11 +70,10 @@ public class AddDocumentDBTests
     }
 
     [Fact]
-    public void WithHostPortConfiguresPrimaryEndpointPort()
+    public void WithHostPortUpdatesExistingTcpEndpoint()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder
-            .AddDocumentDB("DocumentDB")
+        appBuilder.AddDocumentDB("DocumentDB")
             .WithHostPort(10261);
 
         using var app = appBuilder.Build();
@@ -83,9 +82,10 @@ public class AddDocumentDBTests
 
         var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
         var endpoint = Assert.Single(containerResource.Annotations.OfType<EndpointAnnotation>());
+
         Assert.Equal("tcp", endpoint.Name);
-        Assert.Equal(10260, endpoint.TargetPort);
         Assert.Equal(10261, endpoint.Port);
+        Assert.Equal(10260, endpoint.TargetPort);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- expand the repo and NuGet READMEs for DocumentDB users
- add getting started, configuration, troubleshooting, and changelog docs
- improve XML doc comments for the public hosting extensions
- fix follow-up inaccuracies found during doc review

## Validation
- dotnet build azure-databases-aspire.sln
- dotnet test azure-databases-aspire.sln --no-build