### PR TITLE
Upgrade to .NET 10 and Aspire 13.2.2, add Dependabot for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      aspire:
+        patterns:
+          - "Aspire.*"
+    open-pull-requests-limit: 10

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <DefaultTargetFramework>net9.0</DefaultTargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <DefaultTargetFramework>net10.0</DefaultTargetFramework>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
 
     <LangVersion>latest</LangVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,23 +5,23 @@
   </PropertyGroup>
 
   <ItemGroup Label="Production">
-    <PackageVersion Include="Aspire.Hosting" Version="13.1.2" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.2.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test-only">
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/ValidationApp/ValidationApp.csproj
+++ b/ValidationApp/ValidationApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
+  },
+  "msbuild-sdks": {
+    "Aspire.AppHost.Sdk": "13.2.2"
   }
 }

--- a/nuget.config
+++ b/nuget.config
@@ -2,11 +2,11 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="dotnet9">
+    <packageSource key="dotnet10">
       <package pattern="*" />
     </packageSource>
     <packageSource key="nuget.org">

--- a/playground/Playground.csproj
+++ b/playground/Playground.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+<Project Sdk="Aspire.AppHost.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -60,12 +60,8 @@ public static class DocumentDBBuilderExtensions
 
         builder.Eventing.Subscribe<ConnectionStringAvailableEvent>(DocumentDBContainer, async (@event, ct) =>
         {
-            connectionString = await DocumentDBContainer.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
-
-            if (connectionString == null)
-            {
-                throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{DocumentDBContainer.Name}' resource but the connection string was null.");
-            }
+            connectionString = await DocumentDBContainer.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false)
+                ?? throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{DocumentDBContainer.Name}' resource but the connection string was null.");
         });
 
         return builder
@@ -103,12 +99,8 @@ public static class DocumentDBBuilderExtensions
 
         builder.ApplicationBuilder.Eventing.Subscribe<ConnectionStringAvailableEvent>(DocumentDBDatabase, async (@event, ct) =>
         {
-            connectionString = await DocumentDBDatabase.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
-
-            if (connectionString == null)
-            {
-                throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{DocumentDBDatabase.Name}' resource but the connection string was null.");
-            }
+            connectionString = await DocumentDBDatabase.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false)
+                ?? throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{DocumentDBDatabase.Name}' resource but the connection string was null.");
         });
 
         // var healthCheckKey = $"{name}_check";

--- a/tests/Aspire.Hosting.DocumentDB.EndToEndApp/Aspire.Hosting.DocumentDB.EndToEndApp.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.EndToEndApp/Aspire.Hosting.DocumentDB.EndToEndApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+<Project Sdk="Aspire.AppHost.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary

- Upgrade .NET SDK from 9.0.100 to 10.0.100 and TFM to net10.0
- Upgrade Aspire packages from 13.1.2 to 13.2.2
- Bump transitive deps: Microsoft.Extensions.* to 10.0.5, MongoDB.Driver to 3.6.0, OpenTelemetry to 1.15.0
- Move Aspire.AppHost.Sdk version to `global.json` `msbuild-sdks` so Dependabot can manage it
- Add `.github/dependabot.yml` with weekly NuGet schedule and `Aspire.*` grouping
- Update nuget.config feed from dotnet9 to dotnet10
- Fix IDE0270 null-check style errors in DocumentDBBuilderExtensions.cs

## Dependabot Coverage

After this PR, Dependabot will automatically open weekly PRs to update:
- All NuGet packages in `Directory.Packages.props` (including Aspire.*)
- `Aspire.AppHost.Sdk` in `global.json` `msbuild-sdks`
- All Aspire.* packages are grouped into a single PR

## Validation

- Build: 0 errors, 0 warnings
- Tests: 29/29 passed