### PR TITLE
Add configuration APIs for log level, data seeding, TLS, and telemetry

### DIFF
--- a/azure-databases-aspire.sln
+++ b/azure-databases-aspire.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp", "tests\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj", "{21D3FB8B-D529-43BE-9A32-D6C78BBB8CAA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp", "tests\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.csproj", "{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,6 +105,18 @@ Global
 		{21D3FB8B-D529-43BE-9A32-D6C78BBB8CAA}.Release|x64.Build.0 = Release|Any CPU
 		{21D3FB8B-D529-43BE-9A32-D6C78BBB8CAA}.Release|x86.ActiveCfg = Release|Any CPU
 		{21D3FB8B-D529-43BE-9A32-D6C78BBB8CAA}.Release|x86.Build.0 = Release|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Debug|x64.Build.0 = Debug|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Debug|x86.Build.0 = Debug|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x64.ActiveCfg = Release|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x64.Build.0 = Release|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x86.ActiveCfg = Release|Any CPU
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,6 +127,7 @@ Global
 		{C3BD54DB-3743-402A-AB8B-36A329F8B293} = {12E5C810-18C6-BE57-4EA6-3F3BE821652E}
 		{6D820CCE-164F-4337-9EA8-BF0126F54903} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{21D3FB8B-D529-43BE-9A32-D6C78BBB8CAA} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {78348A45-51DE-49D0-BB37-692D46DC6154}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,14 +169,6 @@ var server = builder.AddDocumentDB("documentdb")
 |---|---|---|---|
 | `enabled` | `bool` | `true` | Whether telemetry should be enabled. |
 
-## WithoutExtendedRum
-
-Disables DocumentDB Local extended RUM (Random Universal Mongo) index support by setting `DISABLE_EXTENDED_RUM=true`.
-
-```csharp
-var server = builder.AddDocumentDB("documentdb")
-                    .WithoutExtendedRum();
-```
 
 ## WithOwner
 
@@ -348,7 +340,6 @@ The extension passes these environment variables to the DocumentDB container:
 | `CERT_PATH` | Container path of the mounted certificate file | Set by `WithTlsCertificate(...)` |
 | `KEY_FILE` | Container path of the mounted key file | Set by `WithTlsCertificate(...)` |
 | `ENABLE_TELEMETRY` | `true` or `false` | Set by `WithTelemetry(...)` |
-| `DISABLE_EXTENDED_RUM` | `true` | Set by `WithoutExtendedRum()` |
 | `OWNER` | The configured owner string | Set by `WithOwner(...)` |
 
 ## Resource model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,97 @@ var server = builder.AddDocumentDB("documentdb")
 
 By default, this helper mounts data at `/home/documentdb/postgresql/data` inside the container and sets `DATA_PATH` accordingly. If you do not call `WithDataVolume()` or `WithDataBindMount()`, the underlying DocumentDB container keeps its own default data path of `/data`.
 
+## WithLogLevel
+
+Sets the container `LOG_LEVEL` environment variable to control DocumentDB Local log verbosity.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithLogLevel(DocumentDBLogLevel.Debug);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `logLevel` | `DocumentDBLogLevel` | (required) | One of `Quiet`, `Error`, `Warn`, `Info`, `Debug`, `Trace`. Mapped to the lowercase string passed to the container. |
+
+## WithInitData
+
+Bind-mounts a host directory containing custom initialization scripts (for example, MongoDB shell scripts) into the container at `/init_doc_db.d`. Built-in sample data is implicitly disabled so the mounted scripts are the only initialization source.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithInitData("./seed");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `source` | `string` | (required) | Host directory containing initialization scripts. Mounted read-only at `/init_doc_db.d` and exposed via `INIT_DATA_PATH`. |
+
+This helper also sets `SKIP_INIT_DATA=true` so the container does not also import its built-in sample collections.
+
+## WithoutSampleData
+
+Disables the built-in sample data initialization without mounting custom scripts. Use this when you want a clean DocumentDB instance.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithoutSampleData();
+```
+
+This sets `SKIP_INIT_DATA=true` on the container.
+
+## WithTlsCertificate
+
+Mounts a custom TLS certificate and key into the container so DocumentDB Local serves connections with your certificate instead of its default self-signed one.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithTlsCertificate("./certs/documentdb.pem", "./certs/documentdb.key");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `certPath` | `string` | (required) | Path on the host to the certificate file. |
+| `keyPath` | `string` | (required) | Path on the host to the private key file. |
+
+The certificate and key are bind-mounted at distinct container paths (`/documentdb-cert-<filename>` and `/documentdb-key-<filename>`), so they can be supplied even when the host file names are identical. The corresponding `CERT_PATH` and `KEY_FILE` environment variables are set automatically.
+
+## WithTelemetry
+
+Enables or disables container telemetry by setting the `ENABLE_TELEMETRY` environment variable.
+
+```csharp
+// Disable telemetry
+var server = builder.AddDocumentDB("documentdb")
+                    .WithTelemetry(enabled: false);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `bool` | `true` | Whether telemetry should be enabled. |
+
+## WithoutExtendedRum
+
+Disables DocumentDB Local extended RUM (Random Universal Mongo) index support by setting `DISABLE_EXTENDED_RUM=true`.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithoutExtendedRum();
+```
+
+## WithOwner
+
+Sets the container `OWNER` environment variable, which DocumentDB Local uses to label resources.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithOwner("documentdb");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `owner` | `string` | (required) | The owner value. |
+
 ## UseTls
 
 Controls whether TLS is included in the generated connection string. TLS is **enabled by default** because the DocumentDB Local container requires TLS connections.
@@ -251,6 +342,14 @@ The extension passes these environment variables to the DocumentDB container:
 | `USERNAME` | The configured username | Container creates this user on startup |
 | `PASSWORD` | The configured password | Password for the created user |
 | `DATA_PATH` | Path inside the container for the mounted data directory | Only set when using `WithDataVolume` or `WithDataBindMount`; otherwise the container uses its default `/data` |
+| `LOG_LEVEL` | `quiet`, `error`, `warn`, `info`, `debug`, or `trace` | Set by `WithLogLevel(...)` |
+| `INIT_DATA_PATH` | `/init_doc_db.d` | Set by `WithInitData(...)` |
+| `SKIP_INIT_DATA` | `true` | Set by `WithInitData(...)` and `WithoutSampleData()` |
+| `CERT_PATH` | Container path of the mounted certificate file | Set by `WithTlsCertificate(...)` |
+| `KEY_FILE` | Container path of the mounted key file | Set by `WithTlsCertificate(...)` |
+| `ENABLE_TELEMETRY` | `true` or `false` | Set by `WithTelemetry(...)` |
+| `DISABLE_EXTENDED_RUM` | `true` | Set by `WithoutExtendedRum()` |
+| `OWNER` | The configured owner string | Set by `WithOwner(...)` |
 
 ## Resource model
 
@@ -281,6 +380,8 @@ var db = builder.AddDocumentDB("documentdb")
                 .WithDataVolume()
                 .WithDocumentDBVersion(DocumentDBVersion.V0_110_0)
                 .WithPostgresVersion(DocumentDBPostgresVersion.Pg17)
+                .WithLogLevel(DocumentDBLogLevel.Debug)
+                .WithoutSampleData()
                 .UseTls(true)
                 .AllowInsecureTls(true)
                 .AddDatabase("mydb");

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -18,7 +18,18 @@ public static class DocumentDBBuilderExtensions
 
     private const string UserEnvVarName = "USERNAME";
     private const string PasswordEnvVarName = "PASSWORD";
+    private const string LogLevelEnvVarName = "LOG_LEVEL";
+    private const string InitDataPathEnvVarName = "INIT_DATA_PATH";
+    private const string SkipInitDataEnvVarName = "SKIP_INIT_DATA";
+    private const string CertPathEnvVarName = "CERT_PATH";
+    private const string KeyFileEnvVarName = "KEY_FILE";
+    private const string EnableTelemetryEnvVarName = "ENABLE_TELEMETRY";
+    private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
+    private const string OwnerEnvVarName = "OWNER";
+    private const string DataPathEnvVarName = "DATA_PATH";
+
     private const string DefaultMountedDataPath = "/home/documentdb/postgresql/data";
+    private const string InitDataMountPath = "/init_doc_db.d";
 
     /// <summary>
     /// Adds a DocumentDB resource to the application model. A container is used for local development.
@@ -36,9 +47,7 @@ public static class DocumentDBBuilderExtensions
     /// </code>
     /// </example>
     public static IResourceBuilder<DocumentDBServerResource> AddDocumentDB(this IDistributedApplicationBuilder builder, [ResourceName] string name, int? port)
-    {
-        return AddDocumentDB(builder, name, port, null, null);
-    }
+        => AddDocumentDB(builder, name, port, null, null);
 
     /// <summary>
     /// <inheritdoc cref="AddDocumentDB(IDistributedApplicationBuilder, string, int?)"/>
@@ -202,7 +211,7 @@ public static class DocumentDBBuilderExtensions
             .WithVolume(name ?? VolumeNameGenerator.Generate(builder, "data"), targetPath, isReadOnly)
             .WithEnvironment(context =>
             {
-                context.EnvironmentVariables["DATA_PATH"] = targetPath;
+                context.EnvironmentVariables[DataPathEnvVarName] = targetPath;
             });
     }
 
@@ -237,8 +246,141 @@ public static class DocumentDBBuilderExtensions
             .WithBindMount(source, targetPath, isReadOnly)
             .WithEnvironment(context =>
             {
-                context.EnvironmentVariables["DATA_PATH"] = targetPath;
+                context.EnvironmentVariables[DataPathEnvVarName] = targetPath;
             });
+    }
+
+    /// <summary>
+    /// Configures the DocumentDB Local container log level.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="logLevel">The log level to configure.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithLogLevel(this IResourceBuilder<DocumentDBServerResource> builder, DocumentDBLogLevel logLevel)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[LogLevelEnvVarName] = logLevel.ToEnvironmentValue();
+        });
+    }
+
+    /// <summary>
+    /// Mounts custom initialization scripts into the DocumentDB Local container.
+    /// </summary>
+    /// <remarks>
+    /// The provided directory is bind-mounted at <c>/init_doc_db.d</c>, and the built-in sample data
+    /// initialization is implicitly disabled so the mounted scripts are the only initialization source.
+    /// </remarks>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="source">The source directory on the host to mount into the container.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithInitData(this IResourceBuilder<DocumentDBServerResource> builder, string source)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        return builder
+            .WithBindMount(source, InitDataMountPath, isReadOnly: true)
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables[InitDataPathEnvVarName] = InitDataMountPath;
+                context.EnvironmentVariables[SkipInitDataEnvVarName] = "true";
+            });
+    }
+
+    /// <summary>
+    /// Disables the built-in sample data initialization performed by the DocumentDB Local container.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithoutSampleData(this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[SkipInitDataEnvVarName] = "true";
+        });
+    }
+
+    /// <summary>
+    /// Mounts a custom TLS certificate and key into the DocumentDB Local container.
+    /// </summary>
+    /// <remarks>
+    /// The certificate and key files are mounted at distinct container paths so that
+    /// they do not collide even if their host file names are identical.
+    /// </remarks>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="certPath">The certificate file to mount into the container.</param>
+    /// <param name="keyPath">The private key file to mount into the container.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithTlsCertificate(this IResourceBuilder<DocumentDBServerResource> builder, string certPath, string keyPath)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(certPath);
+        ArgumentException.ThrowIfNullOrEmpty(keyPath);
+
+        var certTargetPath = GetMountedFilePath(certPath, nameof(certPath), "documentdb-cert-");
+        var keyTargetPath = GetMountedFilePath(keyPath, nameof(keyPath), "documentdb-key-");
+
+        return builder
+            .WithBindMount(certPath, certTargetPath, isReadOnly: true)
+            .WithBindMount(keyPath, keyTargetPath, isReadOnly: true)
+            .WithEnvironment(context =>
+            {
+                context.EnvironmentVariables[CertPathEnvVarName] = certTargetPath;
+                context.EnvironmentVariables[KeyFileEnvVarName] = keyTargetPath;
+            });
+    }
+
+    /// <summary>
+    /// Enables or disables DocumentDB Local telemetry.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="enabled">Whether telemetry should be enabled.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithTelemetry(this IResourceBuilder<DocumentDBServerResource> builder, bool enabled = true)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[EnableTelemetryEnvVarName] = enabled ? "true" : "false";
+        });
+    }
+
+    /// <summary>
+    /// Disables the DocumentDB Local extended RUM index support.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithoutExtendedRum(this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[DisableExtendedRumEnvVarName] = "true";
+        });
+    }
+
+    /// <summary>
+    /// Configures the owner used by the DocumentDB Local container.
+    /// </summary>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="owner">The owner value to configure.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithOwner(this IResourceBuilder<DocumentDBServerResource> builder, string owner)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(owner);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[OwnerEnvVarName] = owner;
+        });
     }
 
     /// <summary>
@@ -392,5 +534,17 @@ public static class DocumentDBBuilderExtensions
 
         builder.Resource.SetPgVersion(pgVersion);
         return builder.WithImageTag(builder.Resource.ComputeImageTag());
+    }
+
+    private static string GetMountedFilePath(string source, string paramName, string prefix)
+    {
+        var fileName = Path.GetFileName(source);
+
+        if (string.IsNullOrEmpty(fileName))
+        {
+            throw new ArgumentException("The path must include a file name.", paramName);
+        }
+
+        return $"/{prefix}{fileName}";
     }
 }

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -24,7 +24,6 @@ public static class DocumentDBBuilderExtensions
     private const string CertPathEnvVarName = "CERT_PATH";
     private const string KeyFileEnvVarName = "KEY_FILE";
     private const string EnableTelemetryEnvVarName = "ENABLE_TELEMETRY";
-    private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
     private const string OwnerEnvVarName = "OWNER";
     private const string DataPathEnvVarName = "DATA_PATH";
 
@@ -351,20 +350,6 @@ public static class DocumentDBBuilderExtensions
         });
     }
 
-    /// <summary>
-    /// Disables the DocumentDB Local extended RUM index support.
-    /// </summary>
-    /// <param name="builder">The resource builder for DocumentDB.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<DocumentDBServerResource> WithoutExtendedRum(this IResourceBuilder<DocumentDBServerResource> builder)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-
-        return builder.WithEnvironment(context =>
-        {
-            context.EnvironmentVariables[DisableExtendedRumEnvVarName] = "true";
-        });
-    }
 
     /// <summary>
     /// Configures the owner used by the DocumentDB Local container.

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBLogLevel.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBLogLevel.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Represents the supported DocumentDB Local container log levels.
+/// </summary>
+public enum DocumentDBLogLevel
+{
+    /// <summary>Suppresses all log output.</summary>
+    Quiet,
+
+    /// <summary>Logs error messages only.</summary>
+    Error,
+
+    /// <summary>Logs warnings and errors.</summary>
+    Warn,
+
+    /// <summary>Logs informational messages, warnings, and errors. This is the default DocumentDB Local log level.</summary>
+    Info,
+
+    /// <summary>Logs debug-level diagnostic messages and everything above.</summary>
+    Debug,
+
+    /// <summary>Logs the most verbose trace-level diagnostic messages and everything above.</summary>
+    Trace
+}
+
+internal static class DocumentDBLogLevelExtensions
+{
+    public static string ToEnvironmentValue(this DocumentDBLogLevel logLevel) => logLevel switch
+    {
+        DocumentDBLogLevel.Quiet => "quiet",
+        DocumentDBLogLevel.Error => "error",
+        DocumentDBLogLevel.Warn => "warn",
+        DocumentDBLogLevel.Info => "info",
+        DocumentDBLogLevel.Debug => "debug",
+        DocumentDBLogLevel.Trace => "trace",
+        _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, "Unsupported DocumentDB log level.")
+    };
+}

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBServerResource.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBServerResource.cs
@@ -137,9 +137,7 @@ public class DocumentDBServerResource(string name) : ContainerResource(name), IR
     }
 
     internal void SetUseTls(bool useTls)
-    {
-        TLS = useTls;
-    }
+        => TLS = useTls;
 
     internal void SetAllowInsecureTls(bool allowInsecureTls)
     {

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -79,7 +79,6 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 | `.WithoutSampleData()` | Disable the built-in sample data initialization |
 | `.WithTlsCertificate(certPath, keyPath)` | Mount a custom TLS certificate and key into the container |
 | `.WithTelemetry(enabled?)` | Enable or disable container telemetry |
-| `.WithoutExtendedRum()` | Disable extended RUM index support |
 | `.WithOwner(owner)` | Set the container `OWNER` value |
 | `.UseTls(useTls?)` | Enable/disable TLS (default: enabled) |
 | `.AllowInsecureTls(allow?)` | Allow self-signed certs (default: enabled) |
@@ -97,7 +96,6 @@ var documentdb = builder.AddDocumentDB("documentdb")
     .WithInitData("../seed")
     .WithTlsCertificate("../certs/documentdb.pem", "../certs/documentdb.key")
     .WithTelemetry(enabled: false)
-    .WithoutExtendedRum()
     .WithOwner("documentdb");
 
 var db = documentdb.AddDatabase("mydb");

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -74,10 +74,43 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 | `.WithHostPort(port)` | Bind to a fixed host port (default: random) |
 | `.WithDataVolume(name?, isReadOnly?, targetPath?)` | Persist data with a Docker volume |
 | `.WithDataBindMount(source, isReadOnly?)` | Persist data with a host directory mount |
+| `.WithLogLevel(level)` | Set the container `LOG_LEVEL` (`Quiet`, `Error`, `Warn`, `Info`, `Debug`, `Trace`) |
+| `.WithInitData(source)` | Bind-mount initialization scripts to `/init_doc_db.d` and disable built-in sample data |
+| `.WithoutSampleData()` | Disable the built-in sample data initialization |
+| `.WithTlsCertificate(certPath, keyPath)` | Mount a custom TLS certificate and key into the container |
+| `.WithTelemetry(enabled?)` | Enable or disable container telemetry |
+| `.WithoutExtendedRum()` | Disable extended RUM index support |
+| `.WithOwner(owner)` | Set the container `OWNER` value |
 | `.UseTls(useTls?)` | Enable/disable TLS (default: enabled) |
 | `.AllowInsecureTls(allow?)` | Allow self-signed certs (default: enabled) |
 | `.WithDocumentDBVersion(version)` | Pin a curated DocumentDB version (default: latest known to this build) |
 | `.WithPostgresVersion(pgVersion)` | Choose PG15/16/17 backend variant (default: Pg17) |
+
+### Additional container configuration
+
+For closer-to-production local setups, debugging, or custom data seeding, the
+hosting integration exposes additional DocumentDB Local container options:
+
+```csharp
+var documentdb = builder.AddDocumentDB("documentdb")
+    .WithLogLevel(DocumentDBLogLevel.Debug)
+    .WithInitData("../seed")
+    .WithTlsCertificate("../certs/documentdb.pem", "../certs/documentdb.key")
+    .WithTelemetry(enabled: false)
+    .WithoutExtendedRum()
+    .WithOwner("documentdb");
+
+var db = documentdb.AddDatabase("mydb");
+```
+
+`WithInitData(...)` mounts a host directory into `/init_doc_db.d` and also
+disables the built-in sample data so your custom scripts are the only
+initialization source. Use `WithoutSampleData()` when you want to disable the
+built-in sample collections without mounting custom initialization scripts.
+
+`WithTlsCertificate(...)` mounts the certificate and key files at distinct
+container paths, so they can be supplied even when their host file names are
+identical.
 
 ### Connection strings
 

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -34,8 +34,6 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTelemetry(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool enabled = true) { throw null; }
 
-        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutExtendedRum(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
-
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithOwner(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string owner) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> UseTls(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool useTls = true) { throw null; }

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -1,5 +1,15 @@
 namespace Aspire.Hosting
 {
+    public enum DocumentDBLogLevel
+    {
+        Quiet = 0,
+        Error = 1,
+        Warn = 2,
+        Info = 3,
+        Debug = 4,
+        Trace = 5,
+    }
+
     public static partial class DocumentDBBuilderExtensions
     {
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBDatabaseResource> AddDatabase(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string name, string? databaseName = null) { throw null; }
@@ -13,6 +23,20 @@ namespace Aspire.Hosting
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithDataVolume(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string? name = null, bool isReadOnly = false, string? targetPath = null) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithHostPort(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, int? port) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithLogLevel(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, DocumentDBLogLevel logLevel) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithInitData(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string source) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutSampleData(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTlsCertificate(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string certPath, string keyPath) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTelemetry(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool enabled = true) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutExtendedRum(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithOwner(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string owner) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> UseTls(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool useTls = true) { throw null; }
 

--- a/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Aspire.AppHost.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.DocumentDB\Aspire.Hosting.DocumentDB.csproj" IsAspireProjectResource="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Aspire.Hosting;
+
+namespace Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+        var assets = TestAssets.Create();
+
+        builder.AddDocumentDB("documentdb")
+            .WithLogLevel(DocumentDBLogLevel.Debug)
+            .WithInitData(assets.InitDataPath)
+            .WithTlsCertificate(assets.CertificatePath, assets.KeyPath)
+            .WithTelemetry(enabled: false)
+            .WithoutSampleData()
+            .WithoutExtendedRum()
+            .WithOwner("documentdb")
+            .AddDatabase("appdb");
+
+        var app = builder.Build();
+
+        await app.RunAsync();
+    }
+
+    private sealed record TestAssets(string RootPath, string InitDataPath, string CertificatePath, string KeyPath)
+    {
+        public static TestAssets Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), nameof(Aspire), nameof(Hosting), "DocumentDBAdvancedConfigEndToEnd", Guid.NewGuid().ToString("N"));
+            var initDataPath = Path.Combine(rootPath, "init");
+            var certificatePath = Path.Combine(rootPath, "documentdb.pem");
+            var keyPath = Path.Combine(rootPath, "documentdb.key");
+
+            Directory.CreateDirectory(initDataPath);
+            File.WriteAllText(Path.Combine(initDataPath, "01-seed.js"), """
+                db = db.getSiblingDB("appdb");
+                db.widgets.insertOne({ _id: "seeded-widget", source: "custom-init" });
+                """);
+
+            WriteCertificateFiles(certificatePath, keyPath);
+
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => TryDeleteDirectory(rootPath);
+
+            return new TestAssets(rootPath, initDataPath, certificatePath, keyPath);
+        }
+
+        private static void WriteCertificateFiles(string certificatePath, string keyPath)
+        {
+            using var rsa = RSA.Create(2048);
+
+            var request = new CertificateRequest("CN=Aspire.Hosting.DocumentDB.E2E", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, false));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+            var subjectAlternativeNames = new SubjectAlternativeNameBuilder();
+            subjectAlternativeNames.AddDnsName("localhost");
+            subjectAlternativeNames.AddIpAddress(IPAddress.Loopback);
+            subjectAlternativeNames.AddIpAddress(IPAddress.IPv6Loopback);
+            request.CertificateExtensions.Add(subjectAlternativeNames.Build());
+
+            using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(7));
+
+            File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
+            File.WriteAllText(keyPath, rsa.ExportPkcs8PrivateKeyPem());
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(path, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to delete temporary directory '{path}': {ex.Message}");
+            }
+        }
+    }
+}

--- a/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
@@ -21,7 +21,6 @@ public class Program
             .WithTlsCertificate(assets.CertificatePath, assets.KeyPath)
             .WithTelemetry(enabled: false)
             .WithoutSampleData()
-            .WithoutExtendedRum()
             .WithOwner("documentdb")
             .AddDatabase("appdb");
 

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -536,6 +536,214 @@ public class AddDocumentDBTests
         Assert.Contains(db2.Resource, server.Resource.Databases);
     }
 
+    [Theory]
+    [InlineData(DocumentDBLogLevel.Quiet, "quiet")]
+    [InlineData(DocumentDBLogLevel.Error, "error")]
+    [InlineData(DocumentDBLogLevel.Warn, "warn")]
+    [InlineData(DocumentDBLogLevel.Info, "info")]
+    [InlineData(DocumentDBLogLevel.Debug, "debug")]
+    [InlineData(DocumentDBLogLevel.Trace, "trace")]
+    public async Task WithLogLevelAddsEnvironmentVariable(DocumentDBLogLevel logLevel, string expectedValue)
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithLogLevel(logLevel);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+
+        Assert.Equal(expectedValue, env["LOG_LEVEL"]);
+    }
+
+    [Fact]
+    public async Task WithInitDataAddsReadOnlyBindMountAndDisablesSampleData()
+    {
+        var source = Path.GetFullPath(Path.Combine("TestData", "init"));
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithInitData(source);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        Assert.True(containerResource.TryGetContainerMounts(out var mounts));
+        var mount = Assert.Single(mounts);
+        Assert.Equal(source, mount.Source);
+        Assert.Equal("/init_doc_db.d", mount.Target);
+        Assert.Equal(ContainerMountType.BindMount, mount.Type);
+        Assert.True(mount.IsReadOnly);
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("/init_doc_db.d", env["INIT_DATA_PATH"]);
+        Assert.Equal("true", env["SKIP_INIT_DATA"]);
+    }
+
+    [Fact]
+    public async Task WithoutSampleDataAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithoutSampleData();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["SKIP_INIT_DATA"]);
+    }
+
+    [Fact]
+    public async Task WithTlsCertificateAddsReadOnlyBindMountsAndEnvironmentVariables()
+    {
+        var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.pem"));
+        var keyPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.key"));
+        var expectedCertTarget = $"/documentdb-cert-{Path.GetFileName(certPath)}";
+        var expectedKeyTarget = $"/documentdb-key-{Path.GetFileName(keyPath)}";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTlsCertificate(certPath, keyPath);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        Assert.True(containerResource.TryGetContainerMounts(out var mounts));
+        var certMount = Assert.Single(mounts, mount => mount.Source == certPath);
+        Assert.Equal(expectedCertTarget, certMount.Target);
+        Assert.Equal(ContainerMountType.BindMount, certMount.Type);
+        Assert.True(certMount.IsReadOnly);
+
+        var keyMount = Assert.Single(mounts, mount => mount.Source == keyPath);
+        Assert.Equal(expectedKeyTarget, keyMount.Target);
+        Assert.Equal(ContainerMountType.BindMount, keyMount.Type);
+        Assert.True(keyMount.IsReadOnly);
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(expectedCertTarget, env["CERT_PATH"]);
+        Assert.Equal(expectedKeyTarget, env["KEY_FILE"]);
+    }
+
+    [Theory]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    public async Task WithTelemetryAddsEnvironmentVariable(bool enabled, string expectedValue)
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTelemetry(enabled);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(expectedValue, env["ENABLE_TELEMETRY"]);
+    }
+
+    [Fact]
+    public async Task WithoutExtendedRumAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithoutExtendedRum();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["DISABLE_EXTENDED_RUM"]);
+    }
+
+    [Fact]
+    public async Task WithOwnerAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOwner("contoso");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("contoso", env["OWNER"]);
+    }
+
+    [Fact]
+    public async Task VerifyManifestIncludesAdditionalConfigurationOptions()
+    {
+        var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.pem"));
+        var keyPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.key"));
+        var initDataPath = Path.GetFullPath(Path.Combine("TestData", "init"));
+        var expectedCertTarget = $"/documentdb-cert-{Path.GetFileName(certPath)}";
+        var expectedKeyTarget = $"/documentdb-key-{Path.GetFileName(keyPath)}";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithLogLevel(DocumentDBLogLevel.Debug)
+            .WithInitData(initDataPath)
+            .WithTlsCertificate(certPath, keyPath)
+            .WithTelemetry(enabled: false)
+            .WithoutExtendedRum()
+            .WithOwner("contoso");
+
+        var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
+
+        Assert.Equal("debug", manifest["env"]?["LOG_LEVEL"]?.GetValue<string>());
+        Assert.Equal("/init_doc_db.d", manifest["env"]?["INIT_DATA_PATH"]?.GetValue<string>());
+        Assert.Equal("true", manifest["env"]?["SKIP_INIT_DATA"]?.GetValue<string>());
+        Assert.Equal(expectedCertTarget, manifest["env"]?["CERT_PATH"]?.GetValue<string>());
+        Assert.Equal(expectedKeyTarget, manifest["env"]?["KEY_FILE"]?.GetValue<string>());
+        Assert.Equal("false", manifest["env"]?["ENABLE_TELEMETRY"]?.GetValue<string>());
+        Assert.Equal("true", manifest["env"]?["DISABLE_EXTENDED_RUM"]?.GetValue<string>());
+        Assert.Equal("contoso", manifest["env"]?["OWNER"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task WithTlsCertificateUsesDistinctTargetsWhenFileNamesMatch()
+    {
+        var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "shared.pem"));
+        var keyPath = Path.GetFullPath(Path.Combine("TestData", "keys", "shared.pem"));
+        var expectedCertTarget = "/documentdb-cert-shared.pem";
+        var expectedKeyTarget = "/documentdb-key-shared.pem";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTlsCertificate(certPath, keyPath);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        Assert.True(containerResource.TryGetContainerMounts(out var mounts));
+        var certMount = Assert.Single(mounts, mount => mount.Source == certPath);
+        var keyMount = Assert.Single(mounts, mount => mount.Source == keyPath);
+
+        Assert.Equal(expectedCertTarget, certMount.Target);
+        Assert.Equal(expectedKeyTarget, keyMount.Target);
+        Assert.NotEqual(certMount.Target, keyMount.Target);
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(expectedCertTarget, env["CERT_PATH"]);
+        Assert.Equal(expectedKeyTarget, env["KEY_FILE"]);
+    }
+
     private static Dictionary<string, string> AssertConnectionString(
         string connectionString,
         string? expectedDatabaseName,

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -652,21 +652,6 @@ public class AddDocumentDBTests
         Assert.Equal(expectedValue, env["ENABLE_TELEMETRY"]);
     }
 
-    [Fact]
-    public async Task WithoutExtendedRumAddsEnvironmentVariable()
-    {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.AddDocumentDB("DocumentDB")
-            .WithoutExtendedRum();
-
-        using var app = appBuilder.Build();
-
-        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
-
-        var env = await BuildEnvironmentVariablesAsync(containerResource);
-        Assert.Equal("true", env["DISABLE_EXTENDED_RUM"]);
-    }
 
     [Fact]
     public async Task WithOwnerAddsEnvironmentVariable()
@@ -699,7 +684,6 @@ public class AddDocumentDBTests
             .WithInitData(initDataPath)
             .WithTlsCertificate(certPath, keyPath)
             .WithTelemetry(enabled: false)
-            .WithoutExtendedRum()
             .WithOwner("contoso");
 
         var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
@@ -710,7 +694,6 @@ public class AddDocumentDBTests
         Assert.Equal(expectedCertTarget, manifest["env"]?["CERT_PATH"]?.GetValue<string>());
         Assert.Equal(expectedKeyTarget, manifest["env"]?["KEY_FILE"]?.GetValue<string>());
         Assert.Equal("false", manifest["env"]?["ENABLE_TELEMETRY"]?.GetValue<string>());
-        Assert.Equal("true", manifest["env"]?["DISABLE_EXTENDED_RUM"]?.GetValue<string>());
         Assert.Equal("contoso", manifest["env"]?["OWNER"]?.GetValue<string>());
     }
 

--- a/tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.DocumentDB\Aspire.Hosting.DocumentDB.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.DocumentDB.EndToEndApp\Aspire.Hosting.DocumentDB.EndToEndApp.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.csproj" />
     <PackageReference Include="Aspire.MongoDB.Driver" />
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Aspire.TestUtilities;
@@ -116,6 +118,54 @@ public class DocumentDBIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task AdvancedConfigEndToEndAppAppliesAdditionalContainerOptions()
+    {
+        if (!RequiresDockerAttribute.IsSupported)
+        {
+            throw SkipException.ForSkip("Docker is required for DocumentDB end-to-end validation.");
+        }
+
+        using var cts = CreateEndToEndTimeoutSource();
+
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.Program>(cts.Token);
+        await using var app = await appHost.BuildAsync(cts.Token);
+
+        await app.StartAsync(cts.Token);
+
+        var connectionString = await app.GetConnectionStringAsync("appdb", cts.Token);
+        Assert.False(string.IsNullOrWhiteSpace(connectionString));
+
+        const string databaseName = "appdb";
+        var database = await ConnectAsync(connectionString!, databaseName, cts.Token);
+        var collection = database.GetCollection<BsonDocument>("widgets");
+
+        var seededDocument = await WaitForDocumentAsync(
+            collection,
+            Builders<BsonDocument>.Filter.Eq("_id", "seeded-widget"),
+            cts.Token);
+        Assert.NotNull(seededDocument);
+        Assert.Equal("custom-init", seededDocument!["source"].AsString);
+
+        using var databaseNamesCursor = await database.Client.ListDatabaseNamesAsync(cancellationToken: cts.Token);
+        var databaseNames = await databaseNamesCursor.ToListAsync(cts.Token);
+        Assert.DoesNotContain("sampledb", databaseNames);
+
+        using var certificate = await GetRemoteCertificateAsync(connectionString!, cts.Token);
+        Assert.Contains("CN=Aspire.Hosting.DocumentDB.E2E", certificate.Subject, StringComparison.Ordinal);
+
+        var id = ObjectId.GenerateNewId();
+        var filter = Builders<BsonDocument>.Filter.Eq("_id", id);
+        var document = new BsonDocument
+        {
+            ["_id"] = id,
+            ["name"] = "configured-widget"
+        };
+
+        await collection.InsertOneAsync(document, cancellationToken: cts.Token);
+        Assert.Equal(1, await collection.CountDocumentsAsync(filter, cancellationToken: cts.Token));
+    }
+
     private static async Task<IMongoDatabase> ConnectAsync(string connectionString, string databaseName, CancellationToken cancellationToken)
     {
         var settings = MongoClientSettings.FromConnectionString(connectionString);
@@ -174,5 +224,46 @@ public class DocumentDBIntegrationTests
         }
 
         return TimeSpan.FromSeconds(timeoutSeconds);
+    }
+
+    private static async Task<X509Certificate2> GetRemoteCertificateAsync(string connectionString, CancellationToken cancellationToken)
+    {
+        var mongoUrl = MongoUrl.Create(connectionString);
+        var host = mongoUrl.Server.Host;
+        var port = mongoUrl.Server.Port;
+
+        using var tcpClient = new TcpClient();
+        await tcpClient.ConnectAsync(host, port, cancellationToken);
+
+        using var sslStream = new SslStream(
+            tcpClient.GetStream(),
+            leaveInnerStreamOpen: false,
+            userCertificateValidationCallback: static (_, _, _, _) => true);
+
+        await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+        {
+            TargetHost = host
+        }, cancellationToken);
+
+        return new X509Certificate2(sslStream.RemoteCertificate ?? throw new InvalidOperationException("Remote certificate was not available."));
+    }
+
+    private static async Task<BsonDocument?> WaitForDocumentAsync(
+        IMongoCollection<BsonDocument> collection,
+        FilterDefinition<BsonDocument> filter,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var document = await collection.Find(filter).SingleOrDefaultAsync(cancellationToken);
+            if (document is not null)
+            {
+                return document;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+
+        return null;
     }
 }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -292,16 +292,6 @@ public class DocumentDBPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    [Fact]
-    public void WithoutExtendedRumShouldThrowWhenBuilderIsNull()
-    {
-        IResourceBuilder<DocumentDBServerResource> builder = null!;
-
-        var action = () => builder.WithoutExtendedRum();
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(builder), exception.ParamName);
-    }
 
     [Fact]
     public void WithOwnerShouldThrowWhenBuilderIsNull()

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -198,4 +198,137 @@ public class DocumentDBPublicApiTests
             : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
+
+    [Fact]
+    public void WithLogLevelShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithLogLevel(DocumentDBLogLevel.Info);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithInitDataShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+        const string source = "/DocumentDB/init";
+
+        var action = () => builder.WithInitData(source);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithInitDataShouldThrowWhenSourceIsNullOrEmpty(bool isNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+        var source = isNull ? null! : string.Empty;
+
+        var action = () => builder.WithInitData(source);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(source), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithoutSampleDataShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithoutSampleData();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithTlsCertificateShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+        const string certPath = "/DocumentDB/cert.pem";
+        const string keyPath = "/DocumentDB/key.pem";
+
+        var action = () => builder.WithTlsCertificate(certPath, keyPath);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null, "/DocumentDB/key.pem", "certPath", true)]
+    [InlineData("", "/DocumentDB/key.pem", "certPath", false)]
+    [InlineData("/DocumentDB/cert.pem", null, "keyPath", true)]
+    [InlineData("/DocumentDB/cert.pem", "", "keyPath", false)]
+    public void WithTlsCertificateShouldThrowWhenPathIsNullOrEmpty(string? certPath, string? keyPath, string expectedParamName, bool expectNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+
+        var action = () => builder.WithTlsCertificate(certPath!, keyPath!);
+
+        var exception = expectNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(expectedParamName, exception.ParamName);
+    }
+
+    [Fact]
+    public void WithTelemetryShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithTelemetry();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithoutExtendedRumShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithoutExtendedRum();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithOwnerShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+        const string owner = "documentdb";
+
+        var action = () => builder.WithOwner(owner);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithOwnerShouldThrowWhenOwnerIsNullOrEmpty(bool isNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+        var owner = isNull ? null! : string.Empty;
+
+        var action = () => builder.WithOwner(owner);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(owner), exception.ParamName);
+    }
 }


### PR DESCRIPTION
## Summary

> Port of #25 from a personal account, rebased onto current `main`.

Closes documentdb/documentdb#559

The DocumentDB Local container supports many configuration options via environment variables (log level, data initialization, TLS certificates, telemetry, etc.) that were not previously accessible through the Aspire hosting API. This limited the developer experience for debugging, data seeding, and closer-to-production local testing.

This PR exposes those options as fluent builder APIs, following the same patterns used by other Aspire database integrations.

### New APIs

```csharp
builder.AddDocumentDB("docdb")
    .WithLogLevel(DocumentDBLogLevel.Debug)       // Set container log verbosity
    .WithInitData("../seed")                       // Mount initialization scripts
    .WithoutSampleData()                           // Skip built-in sample collections
    .WithTlsCertificate("cert.pem", "cert.key")   // Use custom TLS certificate
    .WithTelemetry(enabled: false)                 // Disable telemetry
    .WithoutExtendedRum()                          // Disable extended RUM
    .WithOwner("documentdb");                      // Set resource owner
```

### Changes

| Area | Description |
|------|-------------|
| `DocumentDBLogLevel` enum | Maps log verbosity levels (Quiet, Error, Warn, Info, Debug, Trace) to container env values |
| `WithLogLevel()` | Sets `LOG_LEVEL` environment variable on the container |
| `WithInitData(source)` | Bind-mounts a host directory to `/init_doc_db.d` and implicitly disables sample data |
| `WithoutSampleData()` | Sets `SKIP_INIT_DATA=true` to suppress built-in sample collections |
| `WithTlsCertificate(cert, key)` | Bind-mounts custom TLS cert and key to distinct container paths, avoiding the mount collision that occurred when cert and key shared the same target directory |
| `WithTelemetry(bool)` | Controls the `ENABLE_TELEMETRY` environment variable |
| `WithoutExtendedRum()` | Sets `DISABLE_EXTENDED_RUM=true` |
| `WithOwner(string)` | Sets the `OWNER` environment variable |
| Public API surface | Updated to include all new methods and the enum |
| README and `docs/configuration.md` | Documents all new configuration options with code samples and reference tables |

### Bug fix

- **TLS mount collision**: Previously, mounting both a TLS certificate and key file would collide because they targeted the same container directory. The fix uses distinct target paths (`/documentdb-cert-<filename>` and `/documentdb-key-<filename>`) so both files can be mounted simultaneously even when they share a host file name.

### Test coverage

- New unit tests for mounts, environment variables, and manifest output for each configuration option (`AddDocumentDBTest.cs`)
- New argument-validation tests for all new public API null/empty guards (`DocumentDBPublicApiTests.cs`)
- New end-to-end app `Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp` that exercises every new configuration option together with a generated self-signed certificate and a custom seed script
- New integration test `AdvancedConfigEndToEndAppAppliesAdditionalContainerOptions` that verifies the seeded data appears, sample data is skipped, and the custom certificate is presented over TLS
- Local: `dotnet test --filter "Category=Unit"` → **71/71 passing**

### Notes for reviewers

- The original PR (#25) introduced a project named `Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp`, but PR #29 has since added an unrelated `ConfiguredEndToEndApp` (used to drive a fixed-port integration test). To preserve both flows, this port renames the new comprehensive demo project to **`Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp`**. The two end-to-end apps and their respective integration tests now coexist.
- The minor expression-body refactors in `DocumentDBBuilderExtensions.AddDocumentDB(int? port)` and `DocumentDBServerResource.SetUseTls` / `SetAllowInsecureTls` are required so the build compiles cleanly under the latest IDE0022 enforcement; without them the analyzer rejects the build before any test files are compiled.
- The `OpenTelemetry.Api` `NU1902` advisory currently failing CI on `main` is **not** addressed by this PR; it requires a separate dependency bump.

