### PR TITLE
Pin SharpCompress and Snappier to fix NuGet vulnerability audit errors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,12 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
   </ItemGroup>
 
+  <!-- Pin transitive dependencies to resolve known vulnerabilities -->
+  <ItemGroup Label="Transitive pins">
+    <PackageVersion Include="SharpCompress" Version="0.48.0" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
+  </ItemGroup>
+
   <ItemGroup Label="Test-only">
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />


### PR DESCRIPTION
## Problem

Both `unit-test` and `integration-test` CI jobs fail at the `dotnet restore` step due to NuGet security audit warnings treated as errors (`TreatWarningsAsErrors=true`):

- **NU1902**: `SharpCompress` 0.30.1 has a known moderate severity vulnerability ([GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338))
- **NU1903**: `Snappier` 1.0.0 has a known high severity vulnerability ([GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx))

Failed run: https://github.com/microsoft/azure-databases-aspire/actions/runs/25752749462

## Fix

Pin transitive dependencies in `Directory.Packages.props` to patched versions:

| Package | Vulnerable Version | Pinned Version | Advisory |
|---------|-------------------|---------------|----------|
| SharpCompress | 0.30.1 | 0.48.0 | GHSA-6c8g-7p36-r338 |
| Snappier | 1.0.0 | 1.3.1 | GHSA-pggp-6c3x-2xmx |

Both are transitive dependencies from the MongoDB driver chain. Since `CentralPackageTransitivePinningEnabled` is already enabled, adding `PackageVersion` entries overrides the vulnerable versions.

## Verification

- `dotnet restore` succeeds with 0 errors
- `dotnet build` succeeds with 0 warnings, 0 errors