### PR TITLE
Enable health checks for DocumentDB Aspire resources

### DIFF
--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -3,8 +3,8 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.DocumentDB;
-// using Microsoft.Extensions.DependencyInjection;
-// using MongoDB.Driver;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
 
 namespace Aspire.Hosting;
 
@@ -15,6 +15,7 @@ public static class DocumentDBBuilderExtensions
 {
     // default internal port is 10260.
     private const int DefaultContainerPort = 10260;
+    private const string DefaultHealthCheckDatabaseName = "admin";
 
     private const string UserEnvVarName = "USERNAME";
     private const string PasswordEnvVarName = "PASSWORD";
@@ -34,6 +35,9 @@ public static class DocumentDBBuilderExtensions
     /// Adds a DocumentDB resource to the application model. A container is used for local development.
     /// </summary>
     /// <remarks>
+    /// This resource includes a built-in health check. When this resource is referenced as a dependency
+    /// using the <see cref="ResourceBuilderExtensions.WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/>
+    /// extension method then the dependent resource will wait until the DocumentDB server responds to ping.
     /// This version of the package defaults to the <inheritdoc cref="DocumentDBContainerImageTags.Tag"/> tag of the <inheritdoc cref="DocumentDBContainerImageTags.Image"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
@@ -90,6 +94,16 @@ public static class DocumentDBBuilderExtensions
                 ?? throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{DocumentDBContainer.Name}' resource but the connection string was null.");
         });
 
+        var healthCheckKey = $"{name}_check";
+        // Use a database-scoped check so the MongoDB health check package executes a ping command.
+        IMongoDatabase? database = null;
+        builder.Services.AddHealthChecks()
+            .AddMongoDb(
+                sp => database ??=
+                    new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
+                        .GetDatabase(DefaultHealthCheckDatabaseName),
+                name: healthCheckKey);
+
         return builder
             .AddResource(DocumentDBContainer)
             .WithEndpoint(port: port, targetPort: DefaultContainerPort, name: DocumentDBServerResource.PrimaryEndpointName)
@@ -99,8 +113,8 @@ public static class DocumentDBBuilderExtensions
             {
                 context.EnvironmentVariables[UserEnvVarName] = DocumentDBContainer.UserNameReference;
                 context.EnvironmentVariables[PasswordEnvVarName] = DocumentDBContainer.PasswordParameter!;
-            });
-        //.WithHealthCheck(healthCheckKey);
+            })
+            .WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>
@@ -109,6 +123,9 @@ public static class DocumentDBBuilderExtensions
     /// <remarks>
     /// The database resource inherits the parent server's connection string and appends the database name.
     /// Services should reference the database resource (not the server) via <c>.WithReference(db)</c>.
+    /// This resource includes a built-in health check. When this resource is referenced as a dependency
+    /// using the <see cref="ResourceBuilderExtensions.WaitFor{T}(IResourceBuilder{T}, IResourceBuilder{IResource})"/>
+    /// extension method then the dependent resource will wait until the DocumentDB database responds to ping.
     /// </remarks>
     /// <param name="builder">The DocumentDB server resource builder.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -129,8 +146,8 @@ public static class DocumentDBBuilderExtensions
         // Use the resource name as the database name if it's not provided
         databaseName ??= name;
 
-    var DocumentDBDatabase = new DocumentDBDatabaseResource(name, databaseName, builder.Resource);
-    builder.Resource.AddDatabase(DocumentDBDatabase);
+        var DocumentDBDatabase = new DocumentDBDatabaseResource(name, databaseName, builder.Resource);
+        builder.Resource.AddDatabase(DocumentDBDatabase);
 
         string? connectionString = null;
 
@@ -140,18 +157,19 @@ public static class DocumentDBBuilderExtensions
                 ?? throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{DocumentDBDatabase.Name}' resource but the connection string was null.");
         });
 
-        // var healthCheckKey = $"{name}_check";
-        // // cache the database client so it is reused on subsequent calls to the health check
-        // IMongoDatabase? database = null;
-        // builder.ApplicationBuilder.Services.AddHealthChecks()
-        //     .AddDocumentDB(
-        //         sp => database ??=
-        //             new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
-        //                 .GetDatabase(databaseName),
-        //         name: healthCheckKey);
+        var healthCheckKey = $"{name}_check";
+        // cache the database client so it is reused on subsequent calls to the health check
+        IMongoDatabase? database = null;
+        builder.ApplicationBuilder.Services.AddHealthChecks()
+            .AddMongoDb(
+                sp => database ??=
+                    new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
+                        .GetDatabase(databaseName),
+                name: healthCheckKey);
 
         return builder.ApplicationBuilder
-            .AddResource(DocumentDBDatabase);
+            .AddResource(DocumentDBDatabase)
+            .WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -99,7 +99,7 @@ public static class DocumentDBBuilderExtensions
         IMongoDatabase? database = null;
         builder.Services.AddHealthChecks()
             .AddMongoDb(
-                sp => database ??=
+                _ => database ??=
                     new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
                         .GetDatabase(DefaultHealthCheckDatabaseName),
                 name: healthCheckKey);
@@ -158,11 +158,11 @@ public static class DocumentDBBuilderExtensions
         });
 
         var healthCheckKey = $"{name}_check";
-        // cache the database client so it is reused on subsequent calls to the health check
+        // cache the database instance so it is reused on subsequent calls to the health check
         IMongoDatabase? database = null;
         builder.ApplicationBuilder.Services.AddHealthChecks()
             .AddMongoDb(
-                sp => database ??=
+                _ => database ??=
                     new MongoClient(connectionString ?? throw new InvalidOperationException("Connection string is unavailable"))
                         .GetDatabase(databaseName),
                 name: healthCheckKey);

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -5,6 +5,8 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Aspire.Hosting.DocumentDB.Tests;
@@ -12,6 +14,43 @@ namespace Aspire.Hosting.DocumentDB.Tests;
 [Trait("Category", "Unit")]
 public class AddDocumentDBTests
 {
+    [Fact]
+    public void AddDocumentDBAddsHealthCheckAnnotationToResource()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var documentDB = appBuilder.AddDocumentDB("documentdb");
+
+        Assert.Single(documentDB.Resource.Annotations, a => a is HealthCheckAnnotation hca && hca.Key == "documentdb_check");
+    }
+
+    [Fact]
+    public void AddDatabaseAddsHealthCheckAnnotationToResource()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var database = appBuilder.AddDocumentDB("documentdb")
+            .AddDatabase("appdb");
+
+        Assert.Single(database.Resource.Annotations, a => a is HealthCheckAnnotation hca && hca.Key == "appdb_check");
+    }
+
+    [Fact]
+    public void AddDocumentDBRegistersServerAndDatabaseHealthChecks()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("documentdb")
+            .AddDatabase("appdb");
+
+        using var app = appBuilder.Build();
+
+        var healthCheckOptions = app.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Contains(healthCheckOptions.Registrations, registration => registration.Name == "documentdb_check");
+        Assert.Contains(healthCheckOptions.Registrations, registration => registration.Name == "appdb_check");
+        Assert.NotNull(app.Services.GetRequiredService<HealthCheckService>());
+    }
+
     [Fact]
     public void AddDocumentDBContainerWithDefaultsAddsAnnotationMetadata()
     {

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Testing;
 using Aspire.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Xunit;
@@ -36,6 +37,10 @@ public class DocumentDBIntegrationTests
         await using var app = await appHost.BuildAsync(cts.Token);
 
         await app.StartAsync(cts.Token);
+
+        var healthCheckService = app.Services.GetRequiredService<HealthCheckService>();
+        await WaitForHealthCheckAsync(healthCheckService, "documentdb_check", cts.Token);
+        await WaitForHealthCheckAsync(healthCheckService, "appdb_check", cts.Token);
 
         var connectionString = await app.GetConnectionStringAsync("appdb", cts.Token);
         Assert.False(string.IsNullOrWhiteSpace(connectionString));
@@ -133,6 +138,10 @@ public class DocumentDBIntegrationTests
 
         await app.StartAsync(cts.Token);
 
+        var healthCheckService = app.Services.GetRequiredService<HealthCheckService>();
+        await WaitForHealthCheckAsync(healthCheckService, "documentdb_check", cts.Token);
+        await WaitForHealthCheckAsync(healthCheckService, "appdb_check", cts.Token);
+
         var connectionString = await app.GetConnectionStringAsync("appdb", cts.Token);
         Assert.False(string.IsNullOrWhiteSpace(connectionString));
 
@@ -198,6 +207,33 @@ public class DocumentDBIntegrationTests
         }
 
         throw new InvalidOperationException("DocumentDB did not become reachable in time.", lastException);
+    }
+
+    private static async Task WaitForHealthCheckAsync(HealthCheckService healthCheckService, string healthCheckKey, CancellationToken cancellationToken)
+    {
+        HealthReport? lastReport = null;
+
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            lastReport = await healthCheckService.CheckHealthAsync(
+                registration => registration.Name == healthCheckKey,
+                cancellationToken);
+
+            if (lastReport.Entries.TryGetValue(healthCheckKey, out var entry) && entry.Status == HealthStatus.Healthy)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+
+        var lastMessage = "The health check registration was not found.";
+        if (lastReport is not null && lastReport.Entries.TryGetValue(healthCheckKey, out var lastEntry))
+        {
+            lastMessage = $"{lastEntry.Status}: {lastEntry.Description}";
+        }
+
+        throw new InvalidOperationException($"Health check '{healthCheckKey}' did not become healthy in time. Last result: {lastMessage}");
     }
 
     private static int GetAvailableTcpPort()


### PR DESCRIPTION
## Summary

Register built-in health checks for DocumentDB server and database resources so that `.WaitFor()` works correctly in Aspire AppHosts and the dashboard shows accurate health state.

## What changed

- Uncommented and fixed the existing health check wiring in `DocumentDBBuilderExtensions.cs`
- Uses `AspNetCore.HealthChecks.MongoDb` (`AddMongoDb`) which sends `{ping:1}` -- a command DocumentDB supports without authentication
- Both `AddDocumentDB()` (server) and `AddDatabase()` (database) now register health checks and associate them via `.WithHealthCheck()`
- Added unit tests verifying health check annotations and DI registrations
- Added integration test coverage that waits for health checks before exercising the database

## Why MongoDb health check package

DocumentDB does not ship its own health check library. Since DocumentDB speaks the MongoDB wire protocol and its gateway marks `ping` as `requires_auth: false`, the standard MongoDB health check package works correctly out of the box. This matches the pattern used by other Aspire database integrations.

Closes documentdb/documentdb#558