### PR TITLE
fix: update data volume default path to /data to match container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+- Default data volume path changed from `/home/documentdb/postgresql/data` to `/data` to match the DocumentDB Local container default ([documentdb/documentdb#556](https://github.com/documentdb/documentdb/issues/556))
+
 <!-- auto-generated:documentdb-versions-start -->
 <!-- This block is rewritten by eng/scripts/check-documentdb-versions.py.
      It contains ONLY auto-detected upstream version notes. Manual changelog

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,9 +80,9 @@ var server = builder.AddDocumentDB("documentdb")
 |---|---|---|---|
 | `name` | `string?` | Auto-generated | Docker volume name. When `null`, a name is generated from the application and resource names. |
 | `isReadOnly` | `bool` | `false` | Mount the volume as read-only. |
-| `targetPath` | `string?` | `/home/documentdb/postgresql/data` | Path inside the container where the volume is mounted when this helper is used. |
+| `targetPath` | `string?` | `/data` | Path inside the container where the volume is mounted when this helper is used. |
 
-The bare DocumentDB container defaults `DATA_PATH` to `/data`. This method mounts the volume at `targetPath` and sets the `DATA_PATH` environment variable to match, overriding the container default so DocumentDB writes to the mounted directory.
+This method mounts the volume at `targetPath` (which defaults to `/data`, matching the container default) and sets the `DATA_PATH` environment variable to match so DocumentDB writes to the mounted directory.
 
 ## WithDataBindMount
 
@@ -98,7 +98,7 @@ var server = builder.AddDocumentDB("documentdb")
 | `source` | `string` | (required) | Path on the host machine to mount. |
 | `isReadOnly` | `bool` | `false` | Mount as read-only. |
 
-By default, this helper mounts data at `/home/documentdb/postgresql/data` inside the container and sets `DATA_PATH` accordingly. If you do not call `WithDataVolume()` or `WithDataBindMount()`, the underlying DocumentDB container keeps its own default data path of `/data`.
+By default, this helper mounts data at `/data` inside the container (matching the container default) and sets `DATA_PATH` accordingly.
 
 ## WithLogLevel
 
@@ -321,7 +321,7 @@ mongodb://<username>:<password>@<host>:<port>[/<database>]?authSource=admin&auth
 | TLS | Enabled |
 | Insecure TLS | Enabled (allows self-signed certificates) |
 | Container default data path | `/data` |
-| Persistence helper default path | `/home/documentdb/postgresql/data` |
+| Persistence helper default path | `/data` |
 | Auth mechanism | `SCRAM-SHA-256` |
 | Auth database | `admin` |
 

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class DocumentDBBuilderExtensions
     private const string OwnerEnvVarName = "OWNER";
     private const string DataPathEnvVarName = "DATA_PATH";
 
-    private const string DefaultMountedDataPath = "/home/documentdb/postgresql/data";
+    private const string DefaultMountedDataPath = "/data";
     private const string InitDataMountPath = "/init_doc_db.d";
 
     /// <summary>
@@ -206,7 +206,7 @@ public static class DocumentDBBuilderExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
-    /// <param name="targetPath">The target path inside the container. Defaults to /home/documentdb/postgresql/data when this helper is used.</param>
+    /// <param name="targetPath">The target path inside the container. Defaults to /data to match the container default when this helper is used.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <example>
     /// <code>
@@ -239,7 +239,7 @@ public static class DocumentDBBuilderExtensions
     /// Prefer <see cref="WithDataVolume"/> for most cases. Bind mounts are useful when you need
     /// direct access to the data files on the host filesystem.
     /// The bare DocumentDB container defaults <c>DATA_PATH</c> to <c>/data</c>.
-    /// This helper mounts the directory at <c>/home/documentdb/postgresql/data</c> and sets
+    /// This helper mounts the directory at <c>/data</c> (the container default) and sets
     /// <c>DATA_PATH</c> to the same value so DocumentDB writes to the mounted directory.
     /// </remarks>
     /// <param name="builder">The resource builder.</param>

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -413,12 +413,12 @@ public class AddDocumentDBTests
 
         var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
         var volumeAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerMountAnnotation>().Where(a => a.Type == ContainerMountType.Volume));
-        Assert.Equal("/home/documentdb/postgresql/data", volumeAnnotation.Target);
+        Assert.Equal("/data", volumeAnnotation.Target);
         Assert.False(volumeAnnotation.IsReadOnly);
 
         var env = await BuildEnvironmentVariablesAsync(containerResource);
         var dataPath = Assert.Single(env.Where(entry => entry.Key == "DATA_PATH"));
-        Assert.Equal("/home/documentdb/postgresql/data", dataPath.Value);
+        Assert.Equal("/data", dataPath.Value);
     }
 
     [Fact]
@@ -454,12 +454,12 @@ public class AddDocumentDBTests
 
         var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
         var volumeAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerMountAnnotation>().Where(a => a.Type == ContainerMountType.Volume));
-        Assert.Equal("/home/documentdb/postgresql/data", volumeAnnotation.Target);
+        Assert.Equal("/data", volumeAnnotation.Target);
         Assert.True(volumeAnnotation.IsReadOnly);
 
         var env = await BuildEnvironmentVariablesAsync(containerResource);
         var dataPath = Assert.Single(env.Where(entry => entry.Key == "DATA_PATH"));
-        Assert.Equal("/home/documentdb/postgresql/data", dataPath.Value);
+        Assert.Equal("/data", dataPath.Value);
     }
 
     [Fact]
@@ -476,12 +476,12 @@ public class AddDocumentDBTests
         var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
         var bindMountAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerMountAnnotation>().Where(a => a.Type == ContainerMountType.BindMount));
         Assert.Equal("/host/data", bindMountAnnotation.Source);
-        Assert.Equal("/home/documentdb/postgresql/data", bindMountAnnotation.Target);
+        Assert.Equal("/data", bindMountAnnotation.Target);
         Assert.False(bindMountAnnotation.IsReadOnly);
 
         var env = await BuildEnvironmentVariablesAsync(containerResource);
         var dataPath = Assert.Single(env.Where(entry => entry.Key == "DATA_PATH"));
-        Assert.Equal("/home/documentdb/postgresql/data", dataPath.Value);
+        Assert.Equal("/data", dataPath.Value);
     }
 
     [Fact]
@@ -498,12 +498,12 @@ public class AddDocumentDBTests
         var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
         var bindMountAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerMountAnnotation>().Where(a => a.Type == ContainerMountType.BindMount));
         Assert.Equal("/host/data", bindMountAnnotation.Source);
-        Assert.Equal("/home/documentdb/postgresql/data", bindMountAnnotation.Target);
+        Assert.Equal("/data", bindMountAnnotation.Target);
         Assert.True(bindMountAnnotation.IsReadOnly);
 
         var env = await BuildEnvironmentVariablesAsync(containerResource);
         var dataPath = Assert.Single(env.Where(entry => entry.Key == "DATA_PATH"));
-        Assert.Equal("/home/documentdb/postgresql/data", dataPath.Value);
+        Assert.Equal("/data", dataPath.Value);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`WithDataVolume` and `WithDataBindMount` hardcode `/home/documentdb/postgresql/data` as the default mount target, but the DocumentDB Local container defaults `DATA_PATH` to `/data` (see `emulator_entrypoint.sh:230`).

This mismatch means:
1. The path is confusing for users reading DocumentDB docs (which reference `/data`)
2. If `DATA_PATH` env var is ever not set, the volume mount and actual data dir would diverge, risking data loss

## Fix

Update `DefaultMountedDataPath` from `/home/documentdb/postgresql/data` to `/data` to match the container default. Updated XML doc comments, unit tests, and documentation accordingly.

## Verification

- Cross-checked against `documentdb/documentdb` repo (`emulator_entrypoint.sh:230`): `DATA_PATH=${DATA_PATH:-/data}`
- The entrypoint creates the data directory, sets ownership/permissions, then passes `-d "$DATA_PATH"` to `start_oss_server.sh`
- All 94 unit tests pass

Closes documentdb/documentdb#556