### PR TITLE
Add WithoutExtendedRum() extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- `WithoutExtendedRum()` extension method to disable the `extended_rum` index access method in the DocumentDB Local container ([documentdb/documentdb#470](https://github.com/documentdb/documentdb/pull/470))
+
 ### Fixed
 - Default data volume path changed from `/home/documentdb/postgresql/data` to `/data` to match the DocumentDB Local container default ([documentdb/documentdb#556](https://github.com/documentdb/documentdb/issues/556))
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,17 @@ var server = builder.AddDocumentDB("documentdb")
 
 This sets `SKIP_INIT_DATA=true` on the container.
 
+## WithoutExtendedRum
+
+Disables the `extended_rum` index access method in the DocumentDB Local container. Extended RUM is enabled by default starting with DocumentDB v0.111-0.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithoutExtendedRum();
+```
+
+This sets `DISABLE_EXTENDED_RUM=true` on the container. On container images older than v0.111-0 the environment variable is ignored.
+
 ## WithTlsCertificate
 
 Mounts a custom TLS certificate and key into the container so DocumentDB Local serves connections with your certificate instead of its default self-signed one.
@@ -341,6 +352,7 @@ The extension passes these environment variables to the DocumentDB container:
 | `KEY_FILE` | Container path of the mounted key file | Set by `WithTlsCertificate(...)` |
 | `ENABLE_TELEMETRY` | `true` or `false` | Set by `WithTelemetry(...)` |
 | `OWNER` | The configured owner string | Set by `WithOwner(...)` |
+| `DISABLE_EXTENDED_RUM` | `true` | Set by `WithoutExtendedRum()` |
 
 ## Resource model
 
@@ -373,6 +385,7 @@ var db = builder.AddDocumentDB("documentdb")
                 .WithPostgresVersion(DocumentDBPostgresVersion.Pg17)
                 .WithLogLevel(DocumentDBLogLevel.Debug)
                 .WithoutSampleData()
+                .WithoutExtendedRum()
                 .UseTls(true)
                 .AllowInsecureTls(true)
                 .AddDatabase("mydb");

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class DocumentDBBuilderExtensions
     private const string EnableTelemetryEnvVarName = "ENABLE_TELEMETRY";
     private const string OwnerEnvVarName = "OWNER";
     private const string DataPathEnvVarName = "DATA_PATH";
+    private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
 
     private const string DefaultMountedDataPath = "/data";
     private const string InitDataMountPath = "/init_doc_db.d";
@@ -319,6 +320,26 @@ public static class DocumentDBBuilderExtensions
         return builder.WithEnvironment(context =>
         {
             context.EnvironmentVariables[SkipInitDataEnvVarName] = "true";
+        });
+    }
+
+    /// <summary>
+    /// Disables the <c>extended_rum</c> index access method in the DocumentDB Local container
+    /// by setting <c>DISABLE_EXTENDED_RUM=true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Available in DocumentDB <c>v0.111-0</c> and later. On older container images the
+    /// environment variable is ignored.
+    /// </remarks>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithoutExtendedRum(this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[DisableExtendedRumEnvVarName] = "true";
         });
     }
 

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -77,6 +77,7 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 | `.WithLogLevel(level)` | Set the container `LOG_LEVEL` (`Quiet`, `Error`, `Warn`, `Info`, `Debug`, `Trace`) |
 | `.WithInitData(source)` | Bind-mount initialization scripts to `/init_doc_db.d` and disable built-in sample data |
 | `.WithoutSampleData()` | Disable the built-in sample data initialization |
+| `.WithoutExtendedRum()` | Disable the `extended_rum` index access method (DocumentDB v0.111.0+) |
 | `.WithTlsCertificate(certPath, keyPath)` | Mount a custom TLS certificate and key into the container |
 | `.WithTelemetry(enabled?)` | Enable or disable container telemetry |
 | `.WithOwner(owner)` | Set the container `OWNER` value |
@@ -96,7 +97,8 @@ var documentdb = builder.AddDocumentDB("documentdb")
     .WithInitData("../seed")
     .WithTlsCertificate("../certs/documentdb.pem", "../certs/documentdb.key")
     .WithTelemetry(enabled: false)
-    .WithOwner("documentdb");
+    .WithOwner("documentdb")
+    .WithoutExtendedRum();
 
 var db = documentdb.AddDatabase("mydb");
 ```

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -30,6 +30,8 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutSampleData(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
 
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutExtendedRum(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
+
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTlsCertificate(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string certPath, string keyPath) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTelemetry(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool enabled = true) { throw null; }

--- a/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
@@ -22,6 +22,7 @@ public class Program
             .WithTelemetry(enabled: false)
             .WithoutSampleData()
             .WithOwner("documentdb")
+            .WithoutExtendedRum()
             .AddDatabase("appdb");
 
         var app = builder.Build();

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -641,6 +641,22 @@ public class AddDocumentDBTests
     }
 
     [Fact]
+    public async Task WithoutExtendedRumAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithoutExtendedRum();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["DISABLE_EXTENDED_RUM"]);
+    }
+
+    [Fact]
     public async Task WithTlsCertificateAddsReadOnlyBindMountsAndEnvironmentVariables()
     {
         var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.pem"));
@@ -723,7 +739,8 @@ public class AddDocumentDBTests
             .WithInitData(initDataPath)
             .WithTlsCertificate(certPath, keyPath)
             .WithTelemetry(enabled: false)
-            .WithOwner("contoso");
+            .WithOwner("contoso")
+            .WithoutExtendedRum();
 
         var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
 
@@ -734,6 +751,7 @@ public class AddDocumentDBTests
         Assert.Equal(expectedKeyTarget, manifest["env"]?["KEY_FILE"]?.GetValue<string>());
         Assert.Equal("false", manifest["env"]?["ENABLE_TELEMETRY"]?.GetValue<string>());
         Assert.Equal("contoso", manifest["env"]?["OWNER"]?.GetValue<string>());
+        Assert.Equal("true", manifest["env"]?["DISABLE_EXTENDED_RUM"]?.GetValue<string>());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -323,6 +323,17 @@ public class DocumentDBPublicApiTests
     }
 
     [Fact]
+    public void WithoutExtendedRumShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithoutExtendedRum();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
     public void WithHostPortShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<DocumentDBServerResource> builder = null!;


### PR DESCRIPTION
Expose the upstream DISABLE_EXTENDED_RUM switch (added in DocumentDB
v0.111-0) as a first-class extension method on
IResourceBuilder<DocumentDBServerResource>.

- Add WithoutExtendedRum() following the WithoutSampleData() pattern
- Update public API contract file
- Add unit tests (env var, manifest, null guard)
- Add to AdvancedConfigEndToEndApp for E2E coverage
- Update docs/configuration.md and CHANGELOG.md

Closes #52

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Guanzhou Song <guanzhousong@microsoft.com>
