### PR TITLE
Add WithoutUserCreation() extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 - `WithoutExtendedRum()` extension method to disable the `extended_rum` index access method in the DocumentDB Local container ([documentdb/documentdb#470](https://github.com/documentdb/documentdb/pull/470))
+- `WithoutUserCreation()` extension method to skip automatic user creation on container startup
 
 ### Fixed
 - Default data volume path changed from `/home/documentdb/postgresql/data` to `/data` to match the DocumentDB Local container default ([documentdb/documentdb#556](https://github.com/documentdb/documentdb/issues/556))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,23 @@ var server = builder.AddDocumentDB("documentdb")
 
 This sets `DISABLE_EXTENDED_RUM=true` on the container. On container images older than v0.111-0 the environment variable is ignored.
 
+## WithoutUserCreation
+
+Disables the automatic user creation performed by the DocumentDB Local container on startup. Use only after a previous run has already created the user in persisted storage (`WithDataVolume` or `WithDataBindMount`). To avoid spurious init-data runs on subsequent starts, also call `WithoutSampleData()`.
+
+> [!WARNING]
+> Setting `CREATE_USER=false` on a fresh container (without a persisted user) will cause the container entrypoint to exit non-zero. The container's init-data scripts (both built-in sample data and custom scripts mounted via `WithInitData`) authenticate using the configured credentials, and will fail if the user does not exist. Always pair this method with `WithoutSampleData()` and ensure the user already exists in the persisted data.
+
+```csharp
+// Typical pattern: persist data and skip user creation + sample data on subsequent runs
+var server = builder.AddDocumentDB("documentdb")
+                    .WithDataVolume()
+                    .WithoutUserCreation()
+                    .WithoutSampleData();
+```
+
+This sets `CREATE_USER=false` on the container.
+
 ## WithTlsCertificate
 
 Mounts a custom TLS certificate and key into the container so DocumentDB Local serves connections with your certificate instead of its default self-signed one.
@@ -353,6 +370,7 @@ The extension passes these environment variables to the DocumentDB container:
 | `ENABLE_TELEMETRY` | `true` or `false` | Set by `WithTelemetry(...)` |
 | `OWNER` | The configured owner string | Set by `WithOwner(...)` |
 | `DISABLE_EXTENDED_RUM` | `true` | Set by `WithoutExtendedRum()` |
+| `CREATE_USER` | `false` | Set by `WithoutUserCreation()` |
 
 ## Resource model
 
@@ -386,6 +404,7 @@ var db = builder.AddDocumentDB("documentdb")
                 .WithLogLevel(DocumentDBLogLevel.Debug)
                 .WithoutSampleData()
                 .WithoutExtendedRum()
+                .WithoutUserCreation()
                 .UseTls(true)
                 .AllowInsecureTls(true)
                 .AddDatabase("mydb");

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class DocumentDBBuilderExtensions
     private const string OwnerEnvVarName = "OWNER";
     private const string DataPathEnvVarName = "DATA_PATH";
     private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
+    private const string CreateUserEnvVarName = "CREATE_USER";
 
     private const string DefaultMountedDataPath = "/data";
     private const string InitDataMountPath = "/init_doc_db.d";
@@ -340,6 +341,36 @@ public static class DocumentDBBuilderExtensions
         return builder.WithEnvironment(context =>
         {
             context.EnvironmentVariables[DisableExtendedRumEnvVarName] = "true";
+        });
+    }
+
+    /// <summary>
+    /// Disables the DocumentDB Local container's automatic user creation by setting the
+    /// upstream <c>CREATE_USER=false</c> environment variable.
+    /// </summary>
+    /// <remarks>
+    /// Use only after a previous run has already created the user in persisted storage
+    /// (<see cref="WithDataVolume"/> / <see cref="WithDataBindMount"/>). Setting
+    /// <c>CREATE_USER=false</c> on a fresh container will cause init-data steps to fail
+    /// authentication and the container entrypoint to exit non-zero. To avoid spurious
+    /// init-data runs on subsequent starts, also call <see cref="WithoutSampleData"/>.
+    /// <para>
+    /// <strong>Important:</strong> The container's init-data scripts (both built-in sample data
+    /// and custom scripts mounted via <see cref="WithInitData"/>) authenticate using the
+    /// configured credentials. If the user does not exist because creation was skipped,
+    /// these scripts will fail and the container will exit. Always pair this method with
+    /// <see cref="WithoutSampleData"/> and ensure the user already exists in the persisted data.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<DocumentDBServerResource> WithoutUserCreation(this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[CreateUserEnvVarName] = "false";
         });
     }
 

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -78,6 +78,7 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 | `.WithInitData(source)` | Bind-mount initialization scripts to `/init_doc_db.d` and disable built-in sample data |
 | `.WithoutSampleData()` | Disable the built-in sample data initialization |
 | `.WithoutExtendedRum()` | Disable the `extended_rum` index access method (DocumentDB v0.111.0+) |
+| `.WithoutUserCreation()` | Skip automatic user creation on container startup |
 | `.WithTlsCertificate(certPath, keyPath)` | Mount a custom TLS certificate and key into the container |
 | `.WithTelemetry(enabled?)` | Enable or disable container telemetry |
 | `.WithOwner(owner)` | Set the container `OWNER` value |

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -32,6 +32,8 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutExtendedRum(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
 
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithoutUserCreation(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder) { throw null; }
+
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTlsCertificate(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string certPath, string keyPath) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTelemetry(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool enabled = true) { throw null; }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -657,6 +657,22 @@ public class AddDocumentDBTests
     }
 
     [Fact]
+    public async Task WithoutUserCreationAddsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithoutUserCreation();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("false", env["CREATE_USER"]);
+    }
+
+    [Fact]
     public async Task WithTlsCertificateAddsReadOnlyBindMountsAndEnvironmentVariables()
     {
         var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "documentdb.pem"));
@@ -740,7 +756,8 @@ public class AddDocumentDBTests
             .WithTlsCertificate(certPath, keyPath)
             .WithTelemetry(enabled: false)
             .WithOwner("contoso")
-            .WithoutExtendedRum();
+            .WithoutExtendedRum()
+            .WithoutUserCreation();
 
         var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
 
@@ -752,6 +769,7 @@ public class AddDocumentDBTests
         Assert.Equal("false", manifest["env"]?["ENABLE_TELEMETRY"]?.GetValue<string>());
         Assert.Equal("contoso", manifest["env"]?["OWNER"]?.GetValue<string>());
         Assert.Equal("true", manifest["env"]?["DISABLE_EXTENDED_RUM"]?.GetValue<string>());
+        Assert.Equal("false", manifest["env"]?["CREATE_USER"]?.GetValue<string>());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -323,6 +323,17 @@ public class DocumentDBPublicApiTests
     }
 
     [Fact]
+    public void WithoutUserCreationShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithoutUserCreation();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
     public void WithoutExtendedRumShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<DocumentDBServerResource> builder = null!;


### PR DESCRIPTION
## Summary

Expose the upstream `CREATE_USER` switch as a first-class extension method on `IResourceBuilder<DocumentDBServerResource>`. Setting `CREATE_USER=false` skips automatic user creation on container startup, useful when persistence is enabled or a custom init script provisions the user.

## Changes

| File | Change |
|------|--------|
| `DocumentDBBuilderExtensions.cs` | `CreateUserEnvVarName` constant + `WithoutUserCreation()` method |
| `api/Aspire.Hosting.DocumentDB.cs` | Public API contract entry |
| `AddDocumentDBTest.cs` | `WithoutUserCreationAddsEnvironmentVariable` test + manifest test updated |
| `DocumentDBPublicApiTests.cs` | `WithoutUserCreationShouldThrowWhenBuilderIsNull` null-guard test |
| `README.md` | Configuration table + chaining example |
| `docs/configuration.md` | New section, env var table entry, chaining example |
| `CHANGELOG.md` | Unreleased entry |

## Upstream alignment

Verified against `scripts/emulator_entrypoint.sh`:
- Env var: `CREATE_USER` (L226: default `true`)
- Comparison: `"$CREATE_USER" = "false"` (L419) -- our method sets exactly `"false"`
- Effect: skips `-u $USERNAME -p $PASSWORD` args to `build_and_start_gateway.sh`, passes `-s` instead

## Testing

- **Build**: 0 errors, 0 warnings
- **Unit tests**: 99/99 passed (2 new tests)
  - `WithoutUserCreationAddsEnvironmentVariable` -- env var set correctly
  - `WithoutUserCreationShouldThrowWhenBuilderIsNull` -- null guard works
  - `VerifyManifestIncludesAdditionalConfigurationOptions` -- manifest includes `CREATE_USER=false`

Closes #56