### PR TITLE
Bump Aspire to 13.3.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Production">
-    <PackageVersion Include="Aspire.Hosting" Version="13.2.4" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.5" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.2.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.3.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
@@ -27,7 +27,7 @@
   <ItemGroup Label="Test-only">
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
     "allowPrerelease": false
   },
   "msbuild-sdks": {
-    "Aspire.AppHost.Sdk": "13.2.4"
+    "Aspire.AppHost.Sdk": "13.3.5"
   }
 }


### PR DESCRIPTION
Bumps `Aspire.AppHost.Sdk` from 13.2.4 to 13.3.5 (matching the dependabot PR #64) and also updates the centrally managed Aspire and `Microsoft.Extensions.*` package versions in `Directory.Packages.props` to keep them in sync.

## Why

PR #64 only bumped the SDK in `global.json`. With central package management enabled, `Aspire.Hosting.AppHost 13.3.5` transitively requires `Aspire.Hosting >= 13.3.5` and `Microsoft.Extensions.* >= 10.0.7`, but the centrally managed versions were still pinned to 13.2.4 / 10.0.5. This caused `NU1109` package downgrade errors in CI.

## Changes

- `global.json`: `Aspire.AppHost.Sdk` 13.2.4 -> 13.3.5
- `Directory.Packages.props`:
  - `Aspire.Hosting`, `Aspire.Hosting.Testing`, `Aspire.MongoDB.Driver` 13.2.4 -> 13.3.5
  - `Microsoft.Extensions.Configuration.Binder`, `.Diagnostics.HealthChecks`, `.Hosting`, `.Hosting.Abstractions` 10.0.5 -> 10.0.7

## Validation

- `dotnet restore` clean
- `dotnet build` 0 warnings / 0 errors
- `dotnet test --filter "Category=Unit"` 99/99 passed

Supersedes #64.
