### PR TITLE
Simplify WithoutUserCreation docs and example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,22 +158,14 @@ Disables the automatic user creation performed by the DocumentDB Local container
 > Setting `CREATE_USER=false` on a fresh container (without a persisted user) will cause the container entrypoint to exit non-zero. The container's init-data scripts (both built-in sample data and custom scripts mounted via `WithInitData`) authenticate using the configured credentials, and will fail if the user does not exist. Always pair this method with `WithoutSampleData()` and ensure the user already exists in the persisted data.
 
 ```csharp
-// Use stable credentials so the persisted user matches across container restarts
-var user = builder.AddParameter("db-user");
-var pass = builder.AddParameter("db-pass", secret: true);
-var server = builder.AddDocumentDB("documentdb", userName: user, password: pass)
+// Typical pattern: persist data and skip user creation + sample data on subsequent runs
+var server = builder.AddDocumentDB("documentdb")
                     .WithDataVolume()
                     .WithoutUserCreation()
                     .WithoutSampleData();
 ```
 
 This sets `CREATE_USER=false` on the container.
-
-> [!NOTE]
-> When using `WithoutUserCreation()` with `WithDataVolume`, you must supply stable credentials
-> via the `userName` and `password` parameters. The default auto-generated password changes on
-> each run, which would cause authentication failures against the user created during the
-> initial run.
 
 ## WithTlsCertificate
 

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -361,12 +361,6 @@ public static class DocumentDBBuilderExtensions
     /// these scripts will fail and the container will exit. Always pair this method with
     /// <see cref="WithoutSampleData"/> and ensure the user already exists in the persisted data.
     /// </para>
-    /// <para>
-    /// When combining this method with <see cref="WithDataVolume"/> or <see cref="WithDataBindMount"/>,
-    /// supply stable credentials via the <c>userName</c> and <c>password</c> parameters on
-    /// <c>AddDocumentDB</c>. The default auto-generated password changes on each run,
-    /// which would cause authentication failures against the user created during the initial run.
-    /// </para>
     /// </remarks>
     /// <param name="builder">The resource builder for DocumentDB.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>


### PR DESCRIPTION
Follows up on the `WithoutUserCreation()` feature merged in #62, by removing outdated guidance that recommended supplying stable `userName`/`password` parameters when combining `WithoutUserCreation()` with `WithDataVolume`/`WithDataBindMount`.

## Why

The original note suggested the auto-generated default password would cause auth failures against the persisted user. In practice the parameter values flow through Aspire's parameter store (user-secrets in dev, environment in CI), so they persist across runs and the warning was misleading. The doc example also added a parameter-creation snippet that distracted from the typical pattern.

## Changes

- `docs/configuration.md` — Removed the `[!NOTE]` block and simplified the example to the typical `AddDocumentDB().WithDataVolume().WithoutUserCreation().WithoutSampleData()` pattern.
- `src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs` — Removed the corresponding `<para>` block from the XML doc on `WithoutUserCreation()`.

The hard constraint that the user must already exist in the persisted data (the first `>` warning) is preserved.

## Validation

- `dotnet build` 0 warnings / 0 errors
- `dotnet test --filter "Category=Unit"` 99/99 passed
- No public API surface changed

Supersedes #60.
