### PR TITLE
Bump Microsoft.NET.Test.Sdk from 18.5.1 to 18.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />


### PR DESCRIPTION
Bumps `Microsoft.NET.Test.Sdk` from 18.5.1 to 18.6.0. Re-authored from the dependabot PR #65 on top of current `main` (post-#66 Aspire 13.3.5 bump).

## Changes

- `Directory.Packages.props`: `Microsoft.NET.Test.Sdk` 18.5.1 -> 18.6.0

## Validation

- `dotnet restore` clean
- `dotnet build` 0 warnings / 0 errors
- `dotnet test --filter "Category=Unit"` 99/99 passed

Supersedes #65.
