### PR TITLE
Expose PostgreSQL backend endpoint via WithPostgresEndpoint()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - `WithoutExtendedRum()` extension method to disable the `extended_rum` index access method in the DocumentDB Local container ([documentdb/documentdb#470](https://github.com/documentdb/documentdb/pull/470))
 - `WithoutUserCreation()` extension method to skip automatic user creation on container startup
+- `WithPostgresEndpoint()` extension method to opt in to exposing the PostgreSQL backend coordinator port (`9712`), plus `DocumentDBServerResource.PostgresEndpoint` and `DocumentDBServerResource.PostgresConnectionStringExpression` for accessing the `postgresql://` connection string ([#10](https://github.com/microsoft/azure-databases-aspire/issues/10))
 
 ### Fixed
 - Default data volume path changed from `/home/documentdb/postgresql/data` to `/data` to match the DocumentDB Local container default ([documentdb/documentdb#556](https://github.com/documentdb/documentdb/issues/556))

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Then inject `IMongoClient` wherever you need it. The connection string is resolv
 | `.AllowInsecureTls(allowInsecureTls?)` | Allow self-signed certificates (default: enabled) |
 | `.WithDocumentDBVersion(version)` | Pin a curated DocumentDB version (default: latest known to this build) |
 | `.WithPostgresVersion(pgVersion)` | Choose PG15/16/17 backend variant (default: Pg17) |
+| `.WithPostgresEndpoint(port?)` | Also expose the PostgreSQL backend port (9712) and enable `PostgresConnectionStringExpression` |
 
 See the [Configuration Reference](docs/configuration.md) for details, code examples, and default values.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,42 @@ var server = builder.AddDocumentDB("documentdb")
 |---|---|---|---|
 | `pgVersion` | `DocumentDBPostgresVersion` | `Pg17` (when not called) | One of `Pg15`, `Pg16`, `Pg17`. |
 
+## WithPostgresEndpoint
+
+Exposes the PostgreSQL backend coordinator port of the DocumentDB Local container (default container port `9712`) as a second endpoint on the resource, and enables `DocumentDBServerResource.PostgresConnectionStringExpression`.
+
+The `documentdb-local` container bundles a MongoDB-compatible gateway and a PostgreSQL coordinator on separate ports. By default, only the gateway port (`10260`) is published and only a `mongodb://` connection string is generated. Call `WithPostgresEndpoint()` when you also want to talk to the PostgreSQL backend directly (psql / Npgsql / etc.).
+
+```csharp
+var documentDB = builder.AddDocumentDB("documentdb")
+                        .WithPostgresEndpoint();
+
+builder.AddProject<Projects.Worker>("worker")
+       .WithReference(documentDB) // injects the mongodb:// connection string
+       .WithEnvironment("ConnectionStrings__pg", documentDB.Resource.PostgresConnectionStringExpression);
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `port` | `int?` | `null` | Host port to bind to. When `null`, Aspire assigns a random host port. |
+
+### Generated PostgreSQL connection string
+
+```
+postgresql://<username>:<password>@<host>:<port>/postgres
+```
+
+- The same `userName` / `password` parameters as the MongoDB gateway are used, because the upstream container provisions a single admin user shared by both surfaces.
+- The default database is `postgres`, matching the upstream entrypoint's `-d postgres` convention.
+- No `sslmode` query parameter is added, because the bundled PostgreSQL server is started with `ssl = off`; the `UseTls` / `AllowInsecureTls` flags only affect the MongoDB connection string. If you have configured TLS on the PostgreSQL side, append `?sslmode=...` yourself.
+
+> [!NOTE]
+> Accessing `PostgresConnectionStringExpression` before calling `WithPostgresEndpoint()` throws `InvalidOperationException`. Calling `WithPostgresEndpoint()` more than once on the same resource also throws.
+
+Calling this method also sets `ALLOW_EXTERNAL_CONNECTIONS=true` on the container so the upstream entrypoint configures PostgreSQL to listen on all interfaces with a permissive `pg_hba.conf`. Publishing the host port alone is not enough to guarantee external reachability across upstream container revisions.
+
+The supplied `userName`/`password` (default `admin` + auto-generated) are usable as PostgreSQL credentials because the upstream entrypoint creates a real PostgreSQL role via `documentdb_api.create_user(...)` with a SCRAM-SHA-256-hashed password. The same caveat as the gateway side applies: combining this with `WithoutUserCreation()` only works against a persisted data volume that already contains the role.
+
 ## Supported versions
 
 The `DocumentDBVersion` enum is the **curated, append-only** list of versions known to this build of the package. New entries are added by the `check-documentdb-version` GitHub Actions workflow only when the version is published as a non-prerelease GitHub Release on [`documentdb/documentdb`](https://github.com/documentdb/documentdb/releases) AND the `pg15-X.Y.Z`, `pg16-X.Y.Z`, and `pg17-X.Y.Z` container tags all exist on GHCR. Existing entries are never renamed, removed, or renumbered.

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -15,6 +15,8 @@ public static class DocumentDBBuilderExtensions
 {
     // default internal port is 10260.
     private const int DefaultContainerPort = 10260;
+    // default PostgreSQL coordinator port inside the documentdb-local container.
+    private const int DefaultPostgresContainerPort = 9712;
     private const string DefaultHealthCheckDatabaseName = "admin";
 
     private const string UserEnvVarName = "USERNAME";
@@ -29,6 +31,7 @@ public static class DocumentDBBuilderExtensions
     private const string DataPathEnvVarName = "DATA_PATH";
     private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
     private const string CreateUserEnvVarName = "CREATE_USER";
+    private const string AllowExternalConnectionsEnvVarName = "ALLOW_EXTERNAL_CONNECTIONS";
 
     private const string DefaultMountedDataPath = "/data";
     private const string InitDataMountPath = "/init_doc_db.d";
@@ -194,6 +197,71 @@ public static class DocumentDBBuilderExtensions
         {
             endpoint.Port = port;
         });
+    }
+
+    /// <summary>
+    /// Exposes the PostgreSQL backend coordinator port of the DocumentDB Local container
+    /// (default container port <c>9712</c>) as a second endpoint on the resource.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <c>documentdb-local</c> container bundles a MongoDB-compatible gateway and a
+    /// PostgreSQL coordinator listening on separate ports. By default this integration only
+    /// publishes the gateway port (<c>10260</c>) and surfaces a <c>mongodb://</c> connection
+    /// string. Calling <see cref="WithPostgresEndpoint"/> additionally publishes the
+    /// PostgreSQL port so consumers can use psql/Npgsql/etc. directly, and enables
+    /// <see cref="DocumentDBServerResource.PostgresConnectionStringExpression"/>.
+    /// </para>
+    /// <para>
+    /// The endpoint uses the same <c>userName</c>/<c>password</c> parameters as the gateway
+    /// because the container provisions a single admin user shared by both surfaces.
+    /// The default database in the resulting URI is <c>postgres</c>, matching the upstream
+    /// entrypoint, which connects with <c>-d postgres</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="port">
+    /// The host port to bind to. If <see langword="null"/> a random port is assigned.
+    /// </param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <example>
+    /// <code>
+    /// var documentDB = builder.AddDocumentDB("documentdb")
+    ///                         .WithPostgresEndpoint();
+    ///
+    /// builder.AddProject&lt;Projects.Worker&gt;("worker")
+    ///        .WithEnvironment("ConnectionStrings__pg", documentDB.Resource.PostgresConnectionStringExpression);
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<DocumentDBServerResource> WithPostgresEndpoint(
+        this IResourceBuilder<DocumentDBServerResource> builder,
+        int? port = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (builder.Resource.Annotations.OfType<EndpointAnnotation>()
+                .Any(e => e.Name == DocumentDBServerResource.PostgresEndpointName))
+        {
+            throw new InvalidOperationException(
+                $"A PostgreSQL endpoint has already been added to resource '{builder.Resource.Name}'. " +
+                $"Call '{nameof(WithPostgresEndpoint)}()' at most once per DocumentDB resource.");
+        }
+
+        return builder
+            .WithEndpoint(
+                port: port,
+                targetPort: DefaultPostgresContainerPort,
+                scheme: "postgresql",
+                name: DocumentDBServerResource.PostgresEndpointName)
+            .WithEnvironment(context =>
+            {
+                // Explicitly opt the upstream entrypoint into accepting external PostgreSQL
+                // connections (sets PGOPTIONS=-e -> listen_addresses='*' + permissive pg_hba.conf).
+                // Setting this is required so publishing the host port produces a reachable
+                // server even on upstream container builds where the entrypoint's default
+                // ALLOW_EXTERNAL_CONNECTIONS handling is corrected.
+                context.EnvironmentVariables[AllowExternalConnectionsEnvVarName] = "true";
+            });
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBServerResource.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBServerResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -10,11 +12,14 @@ namespace Aspire.Hosting.ApplicationModel;
 public class DocumentDBServerResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
     internal const string PrimaryEndpointName = "tcp";
+    internal const string PostgresEndpointName = "postgres";
     private const string DefaultUserName = "admin";
     private const string DefaultAuthenticationDatabase = "admin";
     private const string DefaultAuthenticationMechanism = "SCRAM-SHA-256";
+    private const string DefaultPostgresDatabase = "postgres";
 
     private EndpointReference? _primaryEndpoint;
+    private EndpointReference? _postgresEndpoint;
 
     /// <summary>
     /// Initialize a resource that represents a DocumentDB container.
@@ -32,6 +37,18 @@ public class DocumentDBServerResource(string name) : ContainerResource(name), IR
     /// Gets the primary endpoint for the DocumentDB server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    /// <summary>
+    /// Gets the PostgreSQL backend endpoint for the DocumentDB server.
+    /// </summary>
+    /// <remarks>
+    /// This endpoint is only allocated when
+    /// <see cref="Aspire.Hosting.DocumentDBBuilderExtensions.WithPostgresEndpoint"/>
+    /// has been called on the resource builder. Accessing
+    /// <see cref="PostgresConnectionStringExpression"/> without first opting in
+    /// throws an <see cref="System.InvalidOperationException"/>.
+    /// </remarks>
+    public EndpointReference PostgresEndpoint => _postgresEndpoint ??= new(this, PostgresEndpointName);
 
     /// <summary>
     /// Gets the parameter that contains the DocumentDB server password.
@@ -78,6 +95,34 @@ public class DocumentDBServerResource(string name) : ContainerResource(name), IR
     /// </summary>
     public ReferenceExpression ConnectionStringExpression => BuildConnectionString();
 
+    /// <summary>
+    /// Gets the PostgreSQL connection string for the DocumentDB server in the standard
+    /// <c>postgresql://user:password@host:port/postgres</c> URI form.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The PostgreSQL backend port (<c>9712</c>) must be exposed via
+    /// <see cref="Aspire.Hosting.DocumentDBBuilderExtensions.WithPostgresEndpoint"/>
+    /// before this property is accessed; otherwise an
+    /// <see cref="System.InvalidOperationException"/> is thrown.
+    /// </para>
+    /// <para>
+    /// The default database in the URI is <c>postgres</c>, matching the upstream
+    /// <c>documentdb-local</c> entrypoint, which connects with <c>-d postgres</c>.
+    /// Credentials come from the same <see cref="UserNameParameter"/> /
+    /// <see cref="PasswordParameter"/> used by the MongoDB gateway because the
+    /// container creates a single admin user shared by both surfaces.
+    /// </para>
+    /// <para>
+    /// No <c>sslmode</c> query parameter is added, because the bundled
+    /// PostgreSQL server is started with <c>ssl = off</c>; the
+    /// <see cref="TLS"/> field of this resource only controls the MongoDB
+    /// gateway. Consumers needing TLS on the PostgreSQL side should append
+    /// <c>?sslmode=...</c> themselves.
+    /// </para>
+    /// </remarks>
+    public ReferenceExpression PostgresConnectionStringExpression => BuildPostgresConnectionString();
+
     internal ReferenceExpression BuildConnectionString(string? databaseName = null)
     {
         var builder = new ReferenceExpressionBuilder();
@@ -119,6 +164,30 @@ public class DocumentDBServerResource(string name) : ContainerResource(name), IR
                 builder.Append($"&tlsInsecure=true");
             }
         }
+
+        return builder.Build();
+    }
+
+    internal ReferenceExpression BuildPostgresConnectionString()
+    {
+        if (!Annotations.OfType<EndpointAnnotation>().Any(e => e.Name == PostgresEndpointName))
+        {
+            throw new InvalidOperationException(
+                $"The PostgreSQL endpoint on resource '{Name}' has not been added. " +
+                $"Call '{nameof(Aspire.Hosting.DocumentDBBuilderExtensions.WithPostgresEndpoint)}()' on " +
+                $"the DocumentDB resource builder before accessing '{nameof(PostgresConnectionStringExpression)}'.");
+        }
+
+        var builder = new ReferenceExpressionBuilder();
+        builder.AppendLiteral("postgresql://");
+
+        if (PasswordParameter is not null)
+        {
+            builder.Append($"{UserNameReference}:{PasswordParameter}@");
+        }
+
+        builder.Append($"{PostgresEndpoint.Property(EndpointProperty.HostAndPort)}");
+        builder.AppendLiteral($"/{DefaultPostgresDatabase}");
 
         return builder.Build();
     }

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -48,6 +48,8 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithPostgresVersion(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, ApplicationModel.DocumentDBPostgresVersion pgVersion) { throw null; }
 
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithPostgresEndpoint(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, int? port = null) { throw null; }
+
     }
 }
 
@@ -70,11 +72,15 @@ namespace Aspire.Hosting.ApplicationModel
 
         public ReferenceExpression ConnectionStringExpression { get { throw null; } }
 
+        public ReferenceExpression PostgresConnectionStringExpression { get { throw null; } }
+
     public System.Collections.Generic.IReadOnlyList<ApplicationModel.DocumentDBDatabaseResource> Databases { get { throw null; } }
 
         public ParameterResource? PasswordParameter { get { throw null; } }
 
         public EndpointReference PrimaryEndpoint { get { throw null; } }
+
+        public EndpointReference PostgresEndpoint { get { throw null; } }
 
         public ParameterResource? UserNameParameter { get { throw null; } }
     }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -773,6 +773,182 @@ public class AddDocumentDBTests
     }
 
     [Fact]
+    public void WithPostgresEndpointAddsSecondEndpointAnnotation()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var endpoints = containerResource.Annotations.OfType<EndpointAnnotation>().ToList();
+        Assert.Equal(2, endpoints.Count);
+
+        var pgEndpoint = Assert.Single(endpoints, e => e.Name == "postgres");
+        Assert.Equal(9712, pgEndpoint.TargetPort);
+        Assert.Null(pgEndpoint.Port);
+        Assert.Equal(ProtocolType.Tcp, pgEndpoint.Protocol);
+        Assert.Equal("postgresql", pgEndpoint.UriScheme);
+    }
+
+    [Fact]
+    public void WithPostgresEndpointBindsCustomHostPort()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint(15432);
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var pgEndpoint = Assert.Single(
+            containerResource.Annotations.OfType<EndpointAnnotation>(),
+            e => e.Name == "postgres");
+        Assert.Equal(9712, pgEndpoint.TargetPort);
+        Assert.Equal(15432, pgEndpoint.Port);
+    }
+
+    [Fact]
+    public void AddDocumentDBDoesNotAddPostgresEndpointByDefault()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB");
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var endpoints = containerResource.Annotations.OfType<EndpointAnnotation>().ToList();
+        Assert.Single(endpoints);
+        Assert.DoesNotContain(endpoints, e => e.Name == "postgres");
+    }
+
+    [Fact]
+    public void PostgresConnectionStringExpressionThrowsWhenEndpointNotAdded()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _ = documentDB.Resource.PostgresConnectionStringExpression);
+
+        Assert.Contains("WithPostgresEndpoint", exception.Message);
+    }
+
+    [Fact]
+    public void PostgresConnectionStringExpressionIncludesCredentialsAndDefaultDatabase()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint();
+
+        var expression = documentDB.Resource.PostgresConnectionStringExpression.ValueExpression;
+
+        Assert.Equal(
+            "postgresql://admin:{DocumentDB-password.value}@" +
+            "{DocumentDB.bindings.postgres.host}:{DocumentDB.bindings.postgres.port}/postgres",
+            expression);
+    }
+
+    [Fact]
+    public async Task PostgresConnectionStringResolvesToReachableUri()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint()
+            .WithEndpoint("postgres", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 25432));
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var passwordParameter = Assert.IsType<ParameterResource>(containerResource.PasswordParameter);
+        var password = await passwordParameter.GetValueAsync(default);
+        Assert.NotNull(password);
+
+        var connectionString = await containerResource.PostgresConnectionStringExpression.GetValueAsync(default);
+        Assert.NotNull(connectionString);
+
+        var uri = new Uri(connectionString!);
+        Assert.Equal("postgresql", uri.Scheme);
+        Assert.Equal("localhost", uri.Host);
+        Assert.Equal(25432, uri.Port);
+        Assert.Equal("/postgres", uri.AbsolutePath);
+        var userInfo = uri.UserInfo.Split(':', 2);
+        Assert.Equal("admin", userInfo[0]);
+        Assert.Equal(password!, userInfo[1]);
+        Assert.Equal(string.Empty, uri.Query);
+    }
+
+    [Fact]
+    public async Task VerifyManifestIncludesPostgresEndpointWhenOptedIn()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint();
+
+        var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
+
+        var bindings = manifest["bindings"];
+        Assert.NotNull(bindings);
+
+        var tcpBinding = bindings!["tcp"];
+        Assert.NotNull(tcpBinding);
+        Assert.Equal(10260, tcpBinding!["targetPort"]?.GetValue<int>());
+
+        var pgBinding = bindings["postgres"];
+        Assert.NotNull(pgBinding);
+        Assert.Equal(9712, pgBinding!["targetPort"]?.GetValue<int>());
+        Assert.Equal("postgresql", pgBinding["scheme"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void WithPostgresEndpointCalledTwiceThrowsInvalidOperation()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => documentDB.WithPostgresEndpoint());
+
+        Assert.Contains("already been added", exception.Message);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointSetsAllowExternalConnectionsEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["ALLOW_EXTERNAL_CONNECTIONS"]);
+    }
+
+    [Fact]
+    public async Task AddDocumentDBDoesNotSetAllowExternalConnectionsByDefault()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB");
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.False(env.ContainsKey("ALLOW_EXTERNAL_CONNECTIONS"));
+    }
+
+    [Fact]
     public async Task WithTlsCertificateUsesDistinctTargetsWhenFileNamesMatch()
     {
         var certPath = Path.GetFullPath(Path.Combine("TestData", "certs", "shared.pem"));

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -355,6 +355,17 @@ public class DocumentDBPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
+    [Fact]
+    public void WithPostgresEndpointShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithPostgresEndpoint();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
     [Theory]
     [InlineData("/some/dir/", "/valid/key.pem", "certPath")]
     [InlineData("/valid/cert.pem", "/some/dir/", "keyPath")]


### PR DESCRIPTION
Closes #10.

Adds an opt-in `WithPostgresEndpoint(int? port = null)` extension method that publishes the DocumentDB Local container's PostgreSQL coordinator port (`9712`) as a second endpoint, plus accessors on `DocumentDBServerResource` for the `postgresql://` connection string.

## Why

`documentdb-local` bundles a MongoDB-compatible gateway and a PostgreSQL coordinator on separate ports. Until now, this integration only published the gateway port (`10260`) and the only generated connection string was `mongodb://...`. Consumers who wanted to talk to the PostgreSQL side directly (`psql`, `Npgsql`, etc.) had no supported way to do it.

## API surface

| Member | Description |
|---|---|
| `WithPostgresEndpoint(int? port = null)` | Adds a second endpoint named `postgres` with `UriScheme=postgresql` and `targetPort=9712`. Sets `ALLOW_EXTERNAL_CONNECTIONS=true` on the container. |
| `DocumentDBServerResource.PostgresEndpoint` | Lazy `EndpointReference` for the published port. |
| `DocumentDBServerResource.PostgresConnectionStringExpression` | `ReferenceExpression` of the form `postgresql://user:password@host:port/postgres`. Throws `InvalidOperationException` if `WithPostgresEndpoint()` has not been called. |

## Design notes

- **Credentials are shared** with the MongoDB gateway because upstream `documentdb-local` provisions a single admin user used by both surfaces (`SetupCustomAdminUser` in `build_and_start_gateway.sh`).
- **Default database `postgres`** matches the upstream entrypoint's `-d postgres` convention.
- **No `sslmode` query parameter** is added because the bundled PostgreSQL server is started with `ssl = off` (`scripts/utils.sh`); the existing `TLS` field only controls the MongoDB gateway. Consumers needing TLS on PG can append `?sslmode=...` themselves.
- **`ALLOW_EXTERNAL_CONNECTIONS=true` is set on the container** when opting in. The upstream entrypoint translates this into `PGOPTIONS=-e` -> `listen_addresses='*'` + a permissive `pg_hba.conf`. Setting it explicitly future-proofs the feature against upstream entrypoint changes; the current entrypoint happens to leak `-e` unconditionally due to a `if VAR="true"; then` typo, but relying on that would silently break the day it is fixed.
- **Opt-in only** — no change to existing `AddDocumentDB` callers; no new endpoint by default.
- **Duplicate-call guard** — calling `WithPostgresEndpoint()` twice on the same resource throws `InvalidOperationException` (rather than silently appending a duplicate annotation).

## Tests

11 new unit tests covering:

- endpoint annotation shape (`name=postgres`, `targetPort=9712`, `UriScheme=postgresql`, `Tcp`)
- custom host port binding
- default-off behavior (no PG endpoint when not opted in)
- `PostgresConnectionStringExpression` throw-when-not-opted-in
- `postgresql://user:pass@host:port/postgres` connection-string format
- runtime URI resolution end-to-end
- manifest includes the second binding when opted in
- `ALLOW_EXTERNAL_CONNECTIONS=true` env var set when opted in / absent by default
- duplicate-call guard
- null-builder guard

Build: 0 warnings / 0 errors. Unit tests: **110/110 passing**.

## Files changed

- `src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs` — new extension method
- `src/Aspire.Hosting.DocumentDB/DocumentDBServerResource.cs` — new endpoint + connection-string accessors
- `src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs` — public API contract additions
- `tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs` — 10 new tests
- `tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs` — 1 new null-guard test
- `docs/configuration.md`, `README.md`, `CHANGELOG.md`

## Follow-up

An integration test that opens a real Npgsql connection against the running container is a sensible follow-up but would require adding `Npgsql` to the test dependencies and extending an EndToEndApp. Out of scope for this PR.
