### PR TITLE
Add WithOpenTelemetryMetrics(); deprecate WithTelemetry (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `WithoutExtendedRum()` extension method to disable the `extended_rum` index access method in the DocumentDB Local container ([documentdb/documentdb#470](https://github.com/documentdb/documentdb/pull/470))
 - `WithoutUserCreation()` extension method to skip automatic user creation on container startup
 - `WithPostgresEndpoint()` extension method to opt in to exposing the PostgreSQL backend coordinator port (`9712`), plus `DocumentDBServerResource.PostgresEndpoint` and `DocumentDBServerResource.PostgresConnectionStringExpression` for accessing the `postgresql://` connection string ([#10](https://github.com/microsoft/azure-databases-aspire/issues/10))
+- `WithOpenTelemetryMetrics(endpoint?, enabled?, exportInterval?, timeout?, serviceName?, serviceVersion?)` extension method to wire the OTLP/gRPC metrics exporter introduced in DocumentDB Local container image `v0.112-0`. Sets `OTEL_METRICS_ENABLED`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`, `OTEL_SERVICE_NAME`, and `OTEL_SERVICE_VERSION` as appropriate ([#72](https://github.com/microsoft/azure-databases-aspire/issues/72))
+
+### Deprecated
+- `WithTelemetry(bool)` is marked `[Obsolete]` with diagnostic ID `ASPIREDOCDB0001`. The `ENABLE_TELEMETRY` environment variable it sets is not consumed by the DocumentDB gateway in container image `v0.112-0` or later, so calling it has no observable effect. The method is retained for binary compatibility and may be removed in a future release. Use `WithOpenTelemetryMetrics(...)` to configure OTLP metrics export instead ([#72](https://github.com/microsoft/azure-databases-aspire/issues/72))
 
 ### Fixed
 - Default data volume path changed from `/home/documentdb/postgresql/data` to `/data` to match the DocumentDB Local container default ([documentdb/documentdb#556](https://github.com/documentdb/documentdb/issues/556))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,19 +183,76 @@ var server = builder.AddDocumentDB("documentdb")
 
 The certificate and key are bind-mounted at distinct container paths (`/documentdb-cert-<filename>` and `/documentdb-key-<filename>`), so they can be supplied even when the host file names are identical. The corresponding `CERT_PATH` and `KEY_FILE` environment variables are set automatically.
 
-## WithTelemetry
+## WithTelemetry (obsolete)
 
-Enables or disables container telemetry by setting the `ENABLE_TELEMETRY` environment variable.
+> **Deprecated since this release.** The `ENABLE_TELEMETRY` environment variable is no longer
+> consumed by the DocumentDB gateway in container image v0.112-0 or later. This method continues
+> to set the variable for binary compatibility but has no observable effect on the running
+> container on those images. Calling it produces compiler diagnostic `ASPIREDOCDB0001`. Use
+> [`WithOpenTelemetryMetrics`](#withopentelemetrymetrics) to configure OTLP metrics export
+> instead. The method may be removed in a future release.
+
+Sets the `ENABLE_TELEMETRY` environment variable. Retained for binary compatibility only.
 
 ```csharp
-// Disable telemetry
+// Disable telemetry (no-op against gateway v0.112-0+; retained for binary compatibility).
 var server = builder.AddDocumentDB("documentdb")
                     .WithTelemetry(enabled: false);
 ```
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | `bool` | `true` | Whether telemetry should be enabled. |
+| `enabled` | `bool` | `true` | Value written to `ENABLE_TELEMETRY`. Not consumed by the gateway in v0.112-0 or later. |
+
+
+## WithOpenTelemetryMetrics
+
+Enables OpenTelemetry metrics export from the DocumentDB gateway via OTLP/gRPC. Requires
+container image v0.112-0 or later. Only metrics are exported today; traces and logs are not yet
+supported by the gateway.
+
+```csharp
+var server = builder.AddDocumentDB("documentdb")
+                    .WithOpenTelemetryMetrics(
+                        endpoint: "http://otel-collector:4317",
+                        exportInterval: TimeSpan.FromSeconds(30),
+                        serviceName: "documentdb-local",
+                        serviceVersion: "0.112.0");
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `endpoint` | `string?` | `null` | OTLP/gRPC endpoint of the collector to receive metrics. When provided, sets `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, which takes precedence over the generic `OTEL_EXPORTER_OTLP_ENDPOINT` per the OpenTelemetry specification. Must be non-empty when provided. |
+| `enabled` | `bool` | `true` | Whether metrics export is enabled. Sets `OTEL_METRICS_ENABLED`. The container default is `false`; calling this method flips it on unless `enabled: false` is passed. |
+| `exportInterval` | `TimeSpan?` | `null` | How often the gateway flushes metrics. When provided, sets `OTEL_METRIC_EXPORT_INTERVAL` (milliseconds, integer, invariant culture). Must be non-negative. |
+| `timeout` | `TimeSpan?` | `null` | Per-export request timeout. When provided, sets `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` (milliseconds, integer, invariant culture). Must be non-negative. |
+| `serviceName` | `string?` | `null` | Logical service name attached to the metrics. When provided, sets `OTEL_SERVICE_NAME`. Must be non-empty when provided. |
+| `serviceVersion` | `string?` | `null` | Logical service version attached to the metrics. When provided, sets `OTEL_SERVICE_VERSION`. Must be non-empty when provided. |
+
+When `endpoint` is omitted, the gateway falls back to the standard OTLP/gRPC default
+(`http://localhost:4317`). In typical Aspire container scenarios that fallback is unreachable,
+so an explicit endpoint pointing to your collector (for example, the Aspire dashboard or an
+OpenTelemetry Collector container) is recommended.
+
+Merge semantics across multiple calls on the same builder:
+
+- `enabled` is non-nullable and is therefore written on every call. The last call's value wins
+  (defaulting to `true` when omitted), even if a previous call set it to `false`. To preserve a
+  `false` setting through subsequent calls, pass `enabled: false` explicitly each time.
+- All other parameters are nullable; later calls override only the environment variables they
+  explicitly set, and values from earlier calls are preserved for parameters left at `null`.
+
+`WithOpenTelemetryMetrics` and the obsolete `WithTelemetry` set disjoint environment variables
+and do not interact.
+
+`exportInterval` and `timeout` are written as integer milliseconds via the invariant culture.
+Values smaller than one millisecond (sub-ms ticks) truncate to `0`; pass whole-millisecond or
+larger granularities.
+
+The gateway also reads `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_TIMEOUT` when the
+signal-specific variants above are unset, plus `OTEL_RESOURCE_ATTRIBUTES`. These are not exposed
+by the typed API — set them via `WithEnvironment(...)` if you need them. Note that
+`OTEL_RESOURCE_ATTRIBUTES` is parsed by the gateway but not yet wired into startup as of v0.112-0.
 
 
 ## WithOwner
@@ -403,7 +460,15 @@ The extension passes these environment variables to the DocumentDB container:
 | `SKIP_INIT_DATA` | `true` | Set by `WithInitData(...)` and `WithoutSampleData()` |
 | `CERT_PATH` | Container path of the mounted certificate file | Set by `WithTlsCertificate(...)` |
 | `KEY_FILE` | Container path of the mounted key file | Set by `WithTlsCertificate(...)` |
-| `ENABLE_TELEMETRY` | `true` or `false` | Set by `WithTelemetry(...)` |
+| `ENABLE_TELEMETRY` | `true` or `false` | Set by `WithTelemetry(...)` — **deprecated**, no longer consumed by the gateway in v0.112-0+ |
+| `OTEL_METRICS_ENABLED` | `true` or `false` | Set by `WithOpenTelemetryMetrics(...)` |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | OTLP/gRPC collector endpoint | Set by `WithOpenTelemetryMetrics(endpoint: ...)` |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Milliseconds (integer) | Set by `WithOpenTelemetryMetrics(exportInterval: ...)` |
+| `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` | Milliseconds (integer) | Set by `WithOpenTelemetryMetrics(timeout: ...)` |
+| `OTEL_SERVICE_NAME` | Service name string | Set by `WithOpenTelemetryMetrics(serviceName: ...)` |
+| `OTEL_SERVICE_VERSION` | Service version string | Set by `WithOpenTelemetryMetrics(serviceVersion: ...)` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/gRPC endpoint | Read by gateway as fallback when `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is unset; not set by the typed API |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | Milliseconds (integer) | Read by gateway as fallback when `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` is unset; not set by the typed API |
 | `OWNER` | The configured owner string | Set by `WithOwner(...)` |
 | `DISABLE_EXTENDED_RUM` | `true` | Set by `WithoutExtendedRum()` |
 | `CREATE_USER` | `false` | Set by `WithoutUserCreation()` |

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.DocumentDB;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,12 @@ public static class DocumentDBBuilderExtensions
     private const string CertPathEnvVarName = "CERT_PATH";
     private const string KeyFileEnvVarName = "KEY_FILE";
     private const string EnableTelemetryEnvVarName = "ENABLE_TELEMETRY";
+    private const string OtelMetricsEnabledEnvVarName = "OTEL_METRICS_ENABLED";
+    private const string OtelExporterOtlpMetricsEndpointEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+    private const string OtelExporterOtlpMetricsTimeoutEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
+    private const string OtelMetricExportIntervalEnvVarName = "OTEL_METRIC_EXPORT_INTERVAL";
+    private const string OtelServiceNameEnvVarName = "OTEL_SERVICE_NAME";
+    private const string OtelServiceVersionEnvVarName = "OTEL_SERVICE_VERSION";
     private const string OwnerEnvVarName = "OWNER";
     private const string DataPathEnvVarName = "DATA_PATH";
     private const string DisableExtendedRumEnvVarName = "DISABLE_EXTENDED_RUM";
@@ -473,11 +480,26 @@ public static class DocumentDBBuilderExtensions
     }
 
     /// <summary>
-    /// Enables or disables DocumentDB Local telemetry.
+    /// Enables or disables DocumentDB Local telemetry by setting the <c>ENABLE_TELEMETRY</c>
+    /// environment variable.
     /// </summary>
     /// <param name="builder">The resource builder for DocumentDB.</param>
     /// <param name="enabled">Whether telemetry should be enabled.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// The <c>ENABLE_TELEMETRY</c> environment variable is not consumed by the DocumentDB gateway
+    /// in container image v0.112-0 or later. On those images this method has no observable effect
+    /// on the running container. Use <see cref="WithOpenTelemetryMetrics(IResourceBuilder{DocumentDBServerResource}, string?, bool, TimeSpan?, TimeSpan?, string?, string?)"/>
+    /// to configure OTLP metrics export.
+    /// </remarks>
+    [Obsolete(
+        "ENABLE_TELEMETRY is not consumed by the DocumentDB gateway in container image v0.112-0 " +
+        "or later, so this method has no observable effect on those images. Use " +
+        "WithOpenTelemetryMetrics(...) for OTLP metrics. This member is kept for binary " +
+        "compatibility and may be removed in a future release.",
+        error: false,
+        DiagnosticId = "ASPIREDOCDB0001",
+        UrlFormat = "https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md#withtelemetry-obsolete")]
     public static IResourceBuilder<DocumentDBServerResource> WithTelemetry(this IResourceBuilder<DocumentDBServerResource> builder, bool enabled = true)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -485,6 +507,158 @@ public static class DocumentDBBuilderExtensions
         return builder.WithEnvironment(context =>
         {
             context.EnvironmentVariables[EnableTelemetryEnvVarName] = enabled ? "true" : "false";
+        });
+    }
+
+    /// <summary>
+    /// Enables OpenTelemetry metrics export from the DocumentDB gateway via OTLP/gRPC.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Requires container image v0.112-0 or later. Only metrics are exported today;
+    /// traces and logs are not yet supported by the gateway.
+    /// </para>
+    /// <para>
+    /// The container default for <c>OTEL_METRICS_ENABLED</c> is <c>false</c>; calling this method
+    /// flips it to <c>true</c> unless <paramref name="enabled"/> is explicitly set to <c>false</c>.
+    /// </para>
+    /// <para>
+    /// Merge semantics across multiple calls on the same builder:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <paramref name="enabled"/> is non-nullable and is therefore written on every call.
+    ///     The last call's value wins (defaulting to <c>true</c> when omitted), even if a
+    ///     previous call set it to <c>false</c>.
+    ///   </item>
+    ///   <item>
+    ///     All other parameters are nullable; later calls override only the environment variables
+    ///     they explicitly set, and values from earlier calls are preserved for parameters left
+    ///     at <see langword="null"/>.
+    ///   </item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// When <paramref name="endpoint"/> is omitted, the gateway falls back to the standard OTLP/gRPC
+    /// default (<c>http://localhost:4317</c>). In an Aspire container scenario, that fallback is
+    /// rarely reachable, so an explicit endpoint pointing to your collector is recommended.
+    /// </para>
+    /// <para>
+    /// <paramref name="exportInterval"/> and <paramref name="timeout"/> are written as integer
+    /// milliseconds via <see cref="CultureInfo.InvariantCulture"/>. Values smaller than one
+    /// millisecond (sub-ms ticks) truncate to <c>0</c>; callers should pass whole-millisecond or
+    /// larger granularities.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The resource builder for DocumentDB.</param>
+    /// <param name="endpoint">
+    /// OTLP/gRPC endpoint of the collector that should receive metrics. When provided, sets
+    /// <c>OTEL_EXPORTER_OTLP_METRICS_ENDPOINT</c> (which takes precedence over the generic
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> per the OpenTelemetry specification). Defaults to
+    /// <see langword="null"/> (leave the environment variable unset; gateway falls back to its
+    /// own default).
+    /// </param>
+    /// <param name="enabled">
+    /// Whether metrics export is enabled. Sets <c>OTEL_METRICS_ENABLED</c>. Defaults to
+    /// <see langword="true"/>: opting into this method clearly indicates the caller wants metrics on.
+    /// </param>
+    /// <param name="exportInterval">
+    /// How often the gateway flushes accumulated metrics to the collector. When provided, sets
+    /// <c>OTEL_METRIC_EXPORT_INTERVAL</c> (milliseconds, integer). Must be non-negative.
+    /// </param>
+    /// <param name="timeout">
+    /// Per-export request timeout. When provided, sets <c>OTEL_EXPORTER_OTLP_METRICS_TIMEOUT</c>
+    /// (milliseconds, integer). Must be non-negative.
+    /// </param>
+    /// <param name="serviceName">
+    /// Logical service name attached to the metrics. When provided, sets <c>OTEL_SERVICE_NAME</c>.
+    /// </param>
+    /// <param name="serviceVersion">
+    /// Logical service version attached to the metrics. When provided, sets
+    /// <c>OTEL_SERVICE_VERSION</c>.
+    /// </param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="endpoint"/>, <paramref name="serviceName"/>, or <paramref name="serviceVersion"/>
+    /// is provided but is empty or whitespace.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="exportInterval"/> or <paramref name="timeout"/> is negative.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// var server = builder.AddDocumentDB("documentdb")
+    ///                     .WithOpenTelemetryMetrics(
+    ///                         endpoint: "http://otel-collector:4317",
+    ///                         exportInterval: TimeSpan.FromSeconds(30));
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<DocumentDBServerResource> WithOpenTelemetryMetrics(
+        this IResourceBuilder<DocumentDBServerResource> builder,
+        string? endpoint = null,
+        bool enabled = true,
+        TimeSpan? exportInterval = null,
+        TimeSpan? timeout = null,
+        string? serviceName = null,
+        string? serviceVersion = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (endpoint is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
+        }
+
+        if (serviceName is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        }
+
+        if (serviceVersion is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(serviceVersion);
+        }
+
+        if (exportInterval is { } ei)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(ei, TimeSpan.Zero, nameof(exportInterval));
+        }
+
+        if (timeout is { } to)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(to, TimeSpan.Zero, nameof(timeout));
+        }
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[OtelMetricsEnabledEnvVarName] = enabled ? "true" : "false";
+
+            if (endpoint is not null)
+            {
+                context.EnvironmentVariables[OtelExporterOtlpMetricsEndpointEnvVarName] = endpoint;
+            }
+
+            if (exportInterval is { } interval)
+            {
+                context.EnvironmentVariables[OtelMetricExportIntervalEnvVarName] =
+                    ((long)interval.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (timeout is { } timeoutValue)
+            {
+                context.EnvironmentVariables[OtelExporterOtlpMetricsTimeoutEnvVarName] =
+                    ((long)timeoutValue.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (serviceName is not null)
+            {
+                context.EnvironmentVariables[OtelServiceNameEnvVarName] = serviceName;
+            }
+
+            if (serviceVersion is not null)
+            {
+                context.EnvironmentVariables[OtelServiceVersionEnvVarName] = serviceVersion;
+            }
         });
     }
 

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -80,7 +80,8 @@ The Aspire integration handles connection string resolution, TLS configuration, 
 | `.WithoutExtendedRum()` | Disable the `extended_rum` index access method (DocumentDB v0.111.0+) |
 | `.WithoutUserCreation()` | Skip automatic user creation on container startup |
 | `.WithTlsCertificate(certPath, keyPath)` | Mount a custom TLS certificate and key into the container |
-| `.WithTelemetry(enabled?)` | Enable or disable container telemetry |
+| `.WithTelemetry(enabled?)` | **Obsolete.** No-op against gateway v0.112-0+; use `.WithOpenTelemetryMetrics(...)` instead. Kept for binary compatibility (`ASPIREDOCDB0001`). |
+| `.WithOpenTelemetryMetrics(endpoint?, enabled?, exportInterval?, timeout?, serviceName?, serviceVersion?)` | Enable OpenTelemetry metrics export from the gateway via OTLP/gRPC (container v0.112-0+) |
 | `.WithOwner(owner)` | Set the container `OWNER` value |
 | `.UseTls(useTls?)` | Enable/disable TLS (default: enabled) |
 | `.AllowInsecureTls(allow?)` | Allow self-signed certs (default: enabled) |
@@ -97,7 +98,7 @@ var documentdb = builder.AddDocumentDB("documentdb")
     .WithLogLevel(DocumentDBLogLevel.Debug)
     .WithInitData("../seed")
     .WithTlsCertificate("../certs/documentdb.pem", "../certs/documentdb.key")
-    .WithTelemetry(enabled: false)
+    .WithOpenTelemetryMetrics(endpoint: "http://otel-collector:4317")
     .WithOwner("documentdb")
     .WithoutExtendedRum();
 

--- a/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
+++ b/src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs
@@ -36,7 +36,10 @@ namespace Aspire.Hosting
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTlsCertificate(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string certPath, string keyPath) { throw null; }
 
+        [Obsolete("ENABLE_TELEMETRY is not consumed by the DocumentDB gateway in container image v0.112-0 or later, so this method has no observable effect on those images. Use WithOpenTelemetryMetrics(...) for OTLP metrics. This member is kept for binary compatibility and may be removed in a future release.", error: false, DiagnosticId = "ASPIREDOCDB0001", UrlFormat = "https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md#withtelemetry-obsolete")]
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithTelemetry(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, bool enabled = true) { throw null; }
+
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithOpenTelemetryMetrics(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string? endpoint = null, bool enabled = true, System.TimeSpan? exportInterval = null, System.TimeSpan? timeout = null, string? serviceName = null, string? serviceVersion = null) { throw null; }
 
         public static ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> WithOwner(this ApplicationModel.IResourceBuilder<ApplicationModel.DocumentDBServerResource> builder, string owner) { throw null; }
 

--- a/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs
@@ -15,6 +15,7 @@ public class Program
         var builder = DistributedApplication.CreateBuilder(args);
         var assets = TestAssets.Create();
 
+#pragma warning disable ASPIREDOCDB0001 // WithTelemetry is obsolete; covered by an integration test.
         builder.AddDocumentDB("documentdb")
             .WithLogLevel(DocumentDBLogLevel.Debug)
             .WithInitData(assets.InitDataPath)
@@ -24,6 +25,7 @@ public class Program
             .WithOwner("documentdb")
             .WithoutExtendedRum()
             .AddDatabase("appdb");
+#pragma warning restore ASPIREDOCDB0001
 
         var app = builder.Build();
 

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -710,9 +710,11 @@ public class AddDocumentDBTests
     [InlineData(false, "false")]
     public async Task WithTelemetryAddsEnvironmentVariable(bool enabled, string expectedValue)
     {
+#pragma warning disable ASPIREDOCDB0001 // WithTelemetry is obsolete; behavior retained for binary compatibility.
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddDocumentDB("DocumentDB")
             .WithTelemetry(enabled);
+#pragma warning restore ASPIREDOCDB0001
 
         using var app = appBuilder.Build();
 
@@ -721,6 +723,250 @@ public class AddDocumentDBTests
 
         var env = await BuildEnvironmentVariablesAsync(containerResource);
         Assert.Equal(expectedValue, env["ENABLE_TELEMETRY"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsSetsEnabledEnvironmentVariable()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics();
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["OTEL_METRICS_ENABLED"]);
+        Assert.False(env.ContainsKey("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"));
+        Assert.False(env.ContainsKey("OTEL_METRIC_EXPORT_INTERVAL"));
+        Assert.False(env.ContainsKey("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"));
+        Assert.False(env.ContainsKey("OTEL_SERVICE_NAME"));
+        Assert.False(env.ContainsKey("OTEL_SERVICE_VERSION"));
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsRespectsExplicitFalse()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(enabled: false);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("false", env["OTEL_METRICS_ENABLED"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsSetsExporterEndpoint()
+    {
+        const string Endpoint = "http://otel-collector:4317";
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(endpoint: Endpoint);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal(Endpoint, env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]);
+        Assert.Equal("true", env["OTEL_METRICS_ENABLED"]);
+        Assert.False(env.ContainsKey("OTEL_EXPORTER_OTLP_ENDPOINT"));
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsSetsExportInterval()
+    {
+        var interval = TimeSpan.FromSeconds(30);
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(exportInterval: interval);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("30000", env["OTEL_METRIC_EXPORT_INTERVAL"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsSetsTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(5);
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(timeout: timeout);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("5000", env["OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsSetsServiceNameAndVersion()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(serviceName: "documentdb-local", serviceVersion: "0.112.0");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("documentdb-local", env["OTEL_SERVICE_NAME"]);
+        Assert.Equal("0.112.0", env["OTEL_SERVICE_VERSION"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsFormatsTimeSpanAsInvariantMilliseconds()
+    {
+        var originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+
+        try
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture =
+                System.Globalization.CultureInfo.GetCultureInfo("tr-TR");
+
+            var appBuilder = DistributedApplication.CreateBuilder();
+            appBuilder.AddDocumentDB("DocumentDB")
+                .WithOpenTelemetryMetrics(
+                    exportInterval: TimeSpan.FromMilliseconds(1234567),
+                    timeout: TimeSpan.FromMilliseconds(2500));
+
+            using var app = appBuilder.Build();
+
+            var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+            var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+            var env = await BuildEnvironmentVariablesAsync(containerResource);
+            Assert.Equal("1234567", env["OTEL_METRIC_EXPORT_INTERVAL"]);
+            Assert.Equal("2500", env["OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"]);
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsCoexistsWithObsoleteWithTelemetry()
+    {
+#pragma warning disable ASPIREDOCDB0001 // WithTelemetry is obsolete; coexistence test ensures no aliasing.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithTelemetry(enabled: false)
+            .WithOpenTelemetryMetrics(enabled: true, endpoint: "http://collector:4317");
+#pragma warning restore ASPIREDOCDB0001
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("false", env["ENABLE_TELEMETRY"]);
+        Assert.Equal("true", env["OTEL_METRICS_ENABLED"]);
+        Assert.Equal("http://collector:4317", env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsMergesAcrossMultipleCalls()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(endpoint: "http://first:4317", serviceName: "first")
+            .WithOpenTelemetryMetrics(enabled: false, serviceName: "second");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("false", env["OTEL_METRICS_ENABLED"]);
+        Assert.Equal("http://first:4317", env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]);
+        Assert.Equal("second", env["OTEL_SERVICE_NAME"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsRewritesEnabledOnEveryCall()
+    {
+        // Documented behavior: `enabled` is non-nullable with default `true`, so every call
+        // rewrites OTEL_METRICS_ENABLED. A later call that omits `enabled` re-enables metrics
+        // even when an earlier call disabled them. Callers must re-pass `enabled: false` to
+        // preserve a disabled state.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(enabled: false)
+            .WithOpenTelemetryMetrics(endpoint: "http://collector:4317");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("true", env["OTEL_METRICS_ENABLED"]);
+        Assert.Equal("http://collector:4317", env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsAllowsZeroTimeSpan()
+    {
+        // Boundary of the non-negative TimeSpan guard: TimeSpan.Zero is accepted and emitted as "0".
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(exportInterval: TimeSpan.Zero, timeout: TimeSpan.Zero);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var containerResource = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+
+        var env = await BuildEnvironmentVariablesAsync(containerResource);
+        Assert.Equal("0", env["OTEL_METRIC_EXPORT_INTERVAL"]);
+        Assert.Equal("0", env["OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"]);
+    }
+
+    [Fact]
+    public async Task WithOpenTelemetryMetricsAddsAllEnvironmentVariablesInManifest()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithOpenTelemetryMetrics(
+                endpoint: "http://otel-collector:4317",
+                enabled: true,
+                exportInterval: TimeSpan.FromSeconds(60),
+                timeout: TimeSpan.FromSeconds(10),
+                serviceName: "documentdb-local",
+                serviceVersion: "0.112.0");
+
+        var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
+
+        Assert.Equal("true", manifest["env"]?["OTEL_METRICS_ENABLED"]?.GetValue<string>());
+        Assert.Equal("http://otel-collector:4317", manifest["env"]?["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]?.GetValue<string>());
+        Assert.Equal("60000", manifest["env"]?["OTEL_METRIC_EXPORT_INTERVAL"]?.GetValue<string>());
+        Assert.Equal("10000", manifest["env"]?["OTEL_EXPORTER_OTLP_METRICS_TIMEOUT"]?.GetValue<string>());
+        Assert.Equal("documentdb-local", manifest["env"]?["OTEL_SERVICE_NAME"]?.GetValue<string>());
+        Assert.Equal("0.112.0", manifest["env"]?["OTEL_SERVICE_VERSION"]?.GetValue<string>());
     }
 
 
@@ -749,6 +995,7 @@ public class AddDocumentDBTests
         var expectedCertTarget = $"/documentdb-cert-{Path.GetFileName(certPath)}";
         var expectedKeyTarget = $"/documentdb-key-{Path.GetFileName(keyPath)}";
 
+#pragma warning disable ASPIREDOCDB0001 // WithTelemetry is obsolete; covered for back-compat in this manifest test.
         var appBuilder = DistributedApplication.CreateBuilder();
         var documentDB = appBuilder.AddDocumentDB("DocumentDB")
             .WithLogLevel(DocumentDBLogLevel.Debug)
@@ -758,6 +1005,7 @@ public class AddDocumentDBTests
             .WithOwner("contoso")
             .WithoutExtendedRum()
             .WithoutUserCreation();
+#pragma warning restore ASPIREDOCDB0001
 
         var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
 
@@ -996,9 +1244,11 @@ public class AddDocumentDBTests
     [Fact]
     public async Task WithTelemetryDefaultsToEnabled()
     {
+#pragma warning disable ASPIREDOCDB0001 // WithTelemetry is obsolete; default-value behavior retained for binary compatibility.
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddDocumentDB("DocumentDB")
             .WithTelemetry();
+#pragma warning restore ASPIREDOCDB0001
 
         using var app = appBuilder.Build();
 

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs
@@ -284,14 +284,92 @@ public class DocumentDBPublicApiTests
     [Fact]
     public void WithTelemetryShouldThrowWhenBuilderIsNull()
     {
+#pragma warning disable ASPIREDOCDB0001 // WithTelemetry is obsolete; null-builder guard retained for binary compatibility.
         IResourceBuilder<DocumentDBServerResource> builder = null!;
 
         var action = () => builder.WithTelemetry();
+#pragma warning restore ASPIREDOCDB0001
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
+    [Fact]
+    public void WithOpenTelemetryMetricsShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<DocumentDBServerResource> builder = null!;
+
+        var action = () => builder.WithOpenTelemetryMetrics();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithOpenTelemetryMetricsShouldThrowWhenEndpointIsEmptyOrWhitespace(string endpoint)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+
+        var action = () => builder.WithOpenTelemetryMetrics(endpoint: endpoint);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(endpoint), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithOpenTelemetryMetricsShouldThrowWhenServiceNameIsEmptyOrWhitespace(string serviceName)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+
+        var action = () => builder.WithOpenTelemetryMetrics(serviceName: serviceName);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(serviceName), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithOpenTelemetryMetricsShouldThrowWhenServiceVersionIsEmptyOrWhitespace(string serviceVersion)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+
+        var action = () => builder.WithOpenTelemetryMetrics(serviceVersion: serviceVersion);
+
+        var exception = Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(serviceVersion), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithOpenTelemetryMetricsShouldThrowWhenExportIntervalIsNegative()
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+
+        var action = () => builder.WithOpenTelemetryMetrics(exportInterval: TimeSpan.FromSeconds(-1));
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(action);
+        Assert.Equal("exportInterval", exception.ParamName);
+    }
+
+    [Fact]
+    public void WithOpenTelemetryMetricsShouldThrowWhenTimeoutIsNegative()
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddDocumentDB("DocumentDB");
+
+        var action = () => builder.WithOpenTelemetryMetrics(timeout: TimeSpan.FromMilliseconds(-1));
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(action);
+        Assert.Equal("timeout", exception.ParamName);
+    }
 
     [Fact]
     public void WithOwnerShouldThrowWhenBuilderIsNull()


### PR DESCRIPTION
## Summary

Closes #72.

Two interrelated changes shipped together:

1. **Add `WithOpenTelemetryMetrics(...)`** — a typed extension method that wires the OTLP/gRPC metrics exporter introduced in DocumentDB Local container image **v0.112-0**.
2. **`[Obsolete]` `WithTelemetry(bool)`** — the existing API sets `ENABLE_TELEMETRY`, which the gateway no longer consumes (per issue's grep evidence). Retained as a no-op shim for binary compatibility.

## What's in the diff

| Area | Change |
|---|---|
| `src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs` | New method + 7 new env-var constants; `[Obsolete]` on `WithTelemetry`. |
| `src/Aspire.Hosting.DocumentDB/api/Aspire.Hosting.DocumentDB.cs` | Public-API contract mirrors both. |
| `src/Aspire.Hosting.DocumentDB/README.md` | Quick-reference table + example updated. |
| `docs/configuration.md` | New `## WithOpenTelemetryMetrics` section; `## WithTelemetry (obsolete)` block; env-var table extended. |
| `CHANGELOG.md` | Entries under `[Unreleased] -> Added` and `Deprecated`. |
| `tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs` | +13 unit tests (defaults, explicit-false, endpoint, interval, timeout, service identity, invariant culture, `TimeSpan.Zero`, multi-call merge, enabled-rewrite, coexistence, manifest). |
| `tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBPublicApiTests.cs` | +6 null/empty/whitespace/negative guard tests. |
| `tests/Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp/Program.cs` | Existing `WithTelemetry` call wrapped in `#pragma warning disable ASPIREDOCDB0001`. |

## API

```csharp
public static IResourceBuilder<DocumentDBServerResource> WithOpenTelemetryMetrics(
    this IResourceBuilder<DocumentDBServerResource> builder,
    string? endpoint = null,
    bool enabled = true,
    TimeSpan? exportInterval = null,
    TimeSpan? timeout = null,
    string? serviceName = null,
    string? serviceVersion = null);

[Obsolete(
    "ENABLE_TELEMETRY is not consumed by the DocumentDB gateway in container image v0.112-0 or later, " +
    "so this method has no observable effect on those images. Use WithOpenTelemetryMetrics(...) for OTLP metrics. " +
    "This member is kept for binary compatibility and may be removed in a future release.",
    error: false,
    DiagnosticId = "ASPIREDOCDB0001",
    UrlFormat = "https://github.com/microsoft/azure-databases-aspire/blob/main/docs/configuration.md#withtelemetry-obsolete")]
public static IResourceBuilder<DocumentDBServerResource> WithTelemetry(this IResourceBuilder<DocumentDBServerResource> builder, bool enabled = true);
```

## Reviewer call-outs

- **Binary-compatible.** `WithTelemetry` body is unchanged. Source-compatible too: `[Obsolete(error: false)]` produces a warning (`ASPIREDOCDB0001`), not an error. Consumers with `TreatWarningsAsErrors=true` can suppress narrowly via the diagnostic ID (this repo's own e2e app and tests do exactly that).
- **`enabled` is rewritten on every call.** It's non-nullable and defaults to `true`, so the last call's value wins — pinned by `WithOpenTelemetryMetricsRewritesEnabledOnEveryCall`. All other parameters are nullable and merge across calls. This is documented in XML doc and `docs/configuration.md` and called out so a chain like `.WithOpenTelemetryMetrics(enabled: false).WithOpenTelemetryMetrics(endpoint: "...")` ends up re-enabled — by design.
- **Endpoint precedence.** `endpoint` maps to `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` (signal-specific, per OTel spec takes precedence over the generic `OTEL_EXPORTER_OTLP_ENDPOINT`). gRPC by default, so no `/v1/metrics` path concerns.
- **Validation.** `ArgumentException.ThrowIfNullOrWhiteSpace` on `endpoint`/`serviceName`/`serviceVersion` when provided; `ArgumentOutOfRangeException.ThrowIfLessThan(..., TimeSpan.Zero)` on `exportInterval`/`timeout`. `TimeSpan.Zero` is a valid boundary (pinned by a test).
- **Formatting.** `TimeSpan` values written as integer milliseconds via `CultureInfo.InvariantCulture`. Verified under `tr-TR` culture. Sub-ms values truncate to `0` (documented).
- **Out of scope** (deliberate, per issue): `OTEL_RESOURCE_ATTRIBUTES` (parsed but unwired upstream), auto-wire to Aspire dashboard OTLP endpoint, traces/logs (gateway only emits metrics today), JSON `TelemetryOptions` overlay.

## Validation

- `dotnet build` — 0 warnings, 0 errors (`TreatWarningsAsErrors=true` repo-wide).
- `dotnet test --filter Category=Unit` — **131/131 passing** (109 prior + 22 new).
- Public API contract file regenerated to include both the new method and the `[Obsolete]` attribute.

## Process

Designed and reviewed via four 5-agent parallel critique rounds — **GPT-5.4, GPT-5.5, Opus 4.6, Opus 4.7, Opus 4.8** — over plan, implementation, tests, and final diff. Notable issues caught and resolved by consensus:

1. `[Obsolete]` + `TreatWarningsAsErrors` would break build → suppression via `#pragma` + stable `DiagnosticId` for downstreams.
2. Missing validation on empty strings / negative `TimeSpan` → guards added.
3. `enabled` non-nullable contradicted "merge preserves earlier values" claim → docs corrected; explicit regression test pinning the actual behavior.
4. Existing `WithTelemetry` docs/README would become misleading → deprecation note + retained back-compat example.
5. Wording-consistency drift across obsolete message / docs / changelog → unified on "no observable effect on v0.112-0+ images".


