### PR TITLE
Add v0.112-0 floor guard for WithPostgresEndpoint() (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - `WithoutExtendedRum()` extension method to disable the `extended_rum` index access method in the DocumentDB Local container ([documentdb/documentdb#470](https://github.com/documentdb/documentdb/pull/470))
 - `WithoutUserCreation()` extension method to skip automatic user creation on container startup
-- `WithPostgresEndpoint()` extension method to opt in to exposing the PostgreSQL backend coordinator port (`9712`), plus `DocumentDBServerResource.PostgresEndpoint` and `DocumentDBServerResource.PostgresConnectionStringExpression` for accessing the `postgresql://` connection string ([#10](https://github.com/microsoft/azure-databases-aspire/issues/10))
+- `WithPostgresEndpoint()` extension method to opt in to exposing the PostgreSQL backend coordinator port (`9712`), plus `DocumentDBServerResource.PostgresEndpoint` and `DocumentDBServerResource.PostgresConnectionStringExpression` for accessing the `postgresql://` connection string ([#10](https://github.com/microsoft/azure-databases-aspire/issues/10)). Requires DocumentDB container image `>= 0.112.0`; see [configuration.md](docs/configuration.md#withpostgresendpoint) for the recovery recipe when an older tag is pinned.
 
 ### Fixed
 - Default data volume path changed from `/home/documentdb/postgresql/data` to `/data` to match the DocumentDB Local container default ([documentdb/documentdb#556](https://github.com/documentdb/documentdb/issues/556))
+- `WithPostgresEndpoint()` now validates the effective container image tag at startup (via `BeforeResourceStartedEvent`) and throws `InvalidOperationException` if the tag is older than `pg{NN}-0.112.0`, preventing the previously silent PostgreSQL authentication failure caused by the legacy `docdb_admin`/`Admin100` admin role in pre-v0.112-0 `documentdb-local` images. Custom images and unknown tag patterns are exempt with a warning. ([#71](https://github.com/microsoft/azure-databases-aspire/issues/71))
 
 <!-- auto-generated:documentdb-versions-start -->
 ### Added (auto-detected upstream DocumentDB versions)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Npgsql" Version="9.0.5" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />

--- a/azure-databases-aspire.sln
+++ b/azure-databases-aspire.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp", "tests\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.csproj", "{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.DocumentDB.PostgresEndToEndApp", "tests\Aspire.Hosting.DocumentDB.PostgresEndToEndApp\Aspire.Hosting.DocumentDB.PostgresEndToEndApp.csproj", "{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,18 @@ Global
 		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x64.Build.0 = Release|Any CPU
 		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x86.ActiveCfg = Release|Any CPU
 		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B}.Release|x86.Build.0 = Release|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Debug|x64.Build.0 = Debug|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Debug|x86.Build.0 = Debug|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Release|x64.ActiveCfg = Release|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Release|x64.Build.0 = Release|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Release|x86.ActiveCfg = Release|Any CPU
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,6 +142,7 @@ Global
 		{6D820CCE-164F-4337-9EA8-BF0126F54903} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{21D3FB8B-D529-43BE-9A32-D6C78BBB8CAA} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{4397CB9A-6777-4DB3-A3F9-DCFE0EC9F45B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{1CDC9AF0-1747-406D-8C4E-B89F33EC5B80} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {78348A45-51DE-49D0-BB37-692D46DC6154}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -293,6 +293,55 @@ builder.AddProject<Projects.Worker>("worker")
 |---|---|---|---|
 | `port` | `int?` | `null` | Host port to bind to. When `null`, Aspire assigns a random host port. |
 
+> [!IMPORTANT]
+> **`WithPostgresEndpoint()` requires DocumentDB container image `>= 0.112.0`.**
+>
+> The `documentdb-local` entrypoint hard-codes the PostgreSQL admin role to
+> `docdb_admin`/`Admin100` on image tags below `0.112.0`, so the
+> `postgresql://admin:<password>@host:port/postgres` connection string Aspire
+> generates would silently fail authentication. To prevent the silent failure,
+> the integration validates the resource's effective `ContainerImageAnnotation`
+> tag at startup and throws an `InvalidOperationException` if it is older than
+> `pg{NN}-0.112.0`. The exception message looks like:
+>
+> ```
+> DocumentDB resource 'documentdb' is configured with image tag 'pg17-0.111.0',
+> but WithPostgresEndpoint() requires DocumentDB v0.112.0 or later. Earlier
+> images hard-code the PostgreSQL admin credentials to 'docdb_admin'/'Admin100',
+> so the Aspire-generated postgresql:// connection string would silently fail to
+> authenticate. Recovery: chain '.WithImageTag("pg{NN}-0.112.0")' (or newer)
+> after AddDocumentDB(...). See https://github.com/microsoft/azure-databases-aspire/issues/71.
+> ```
+>
+> **Recovery recipe:**
+>
+> ```csharp
+> var db = builder.AddDocumentDB("documentdb")
+>                 .WithImageTag("pg17-0.112.0")   // or any newer tag
+>                 .WithPostgresEndpoint();
+> ```
+>
+> Once `DocumentDBVersion.V0_112_0` is added to the curated enum
+> (tracked by issue [#70](https://github.com/microsoft/azure-databases-aspire/issues/70)),
+> the typed form `.WithDocumentDBVersion(DocumentDBVersion.V0_112_0)` becomes
+> available as an equivalent recovery. Until then, prefer the free-form
+> `.WithImageTag(...)` shown above.
+>
+> **Scope of the guard:**
+> - **Run mode only.** Manifest generation (`azd publish`, `--publisher
+>   manifest`) does not start the container, so the guard does not fire and
+>   the manifest is produced regardless of tag.
+> - **Curated image only.** A custom image (any
+>   `ContainerImageAnnotation.Image` other than
+>   `documentdb/documentdb-local`, e.g. a fork via `.WithImage("myorg/build", "pg17-0.110.0")`)
+>   is exempt with a one-time warning. The container registry does not factor
+>   into the carve-out — a private mirror of the curated image is still
+>   guarded.
+> - **Unknown tag patterns** (`:latest`, `:nightly`, `pg17-0.112.0-rc.1`,
+>   custom non-`pg{NN}-X.Y.Z` strings) bypass the version check with a
+>   one-time warning, so pinning a custom build or pre-release does not break
+>   startup.
+
 ### Generated PostgreSQL connection string
 
 ```

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.DocumentDB;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace Aspire.Hosting;
@@ -261,7 +262,126 @@ public static class DocumentDBBuilderExtensions
                 // server even on upstream container builds where the entrypoint's default
                 // ALLOW_EXTERNAL_CONNECTIONS handling is corrected.
                 context.EnvironmentVariables[AllowExternalConnectionsEnvVarName] = "true";
+            })
+            .SubscribeMinimumPostgresImageGuard();
+    }
+
+    /// <summary>
+    /// Subscribes a <see cref="BeforeResourceStartedEvent"/> handler that throws
+    /// <see cref="InvalidOperationException"/> if the resource's effective container image
+    /// tag is older than <see cref="DocumentDBContainerImageTags.MinimumPostgresEndpointVersion"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The handler is registered AFTER endpoint and environment configuration have run,
+    /// but executes at run-time via the orchestrator, which honours the documented
+    /// "last call wins" precedence: a <c>WithImageTag(...)</c> chained after
+    /// <see cref="WithPostgresEndpoint"/> still affects the tag the guard sees.
+    /// </para>
+    /// <para>
+    /// The guard is run-mode only. <see cref="BeforeResourceStartedEvent"/> is not published
+    /// during manifest generation, so <c>azd publish</c> / <c>--publisher manifest</c> flows
+    /// are unaffected — that is intentional, because no container is started in those modes.
+    /// </para>
+    /// <para>
+    /// Custom images (anything whose <see cref="ContainerImageAnnotation.Image"/> is not
+    /// the curated <see cref="DocumentDBContainerImageTags.Image"/>) are exempt with a
+    /// single warning. Tags that do not match the strict <c>pg{NN}-X.Y.Z</c> pattern
+    /// (e.g., <c>nightly</c>, <c>pg17-0.112.0-rc.1</c>) are also exempt with a single
+    /// warning, so callers pinning custom builds or pre-releases are not surprised by an
+    /// unactionable hard failure.
+    /// </para>
+    /// </remarks>
+    private static IResourceBuilder<DocumentDBServerResource> SubscribeMinimumPostgresImageGuard(
+        this IResourceBuilder<DocumentDBServerResource> builder)
+    {
+        // Captured per-resource one-shot flag so unknown-tag / custom-image warnings
+        // don't spam on every restart attempt. Hard-failure exceptions are deterministic
+        // and intentionally re-thrown on each start attempt. Interlocked guard makes
+        // the at-most-once property memory-safe even if a future Aspire orchestrator
+        // dispatches BeforeResourceStartedEvent concurrently for the same resource.
+        var warningLogged = 0;
+
+        builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(
+            builder.Resource,
+            (evt, ct) =>
+            {
+                var imageAnnotation = evt.Resource.Annotations.OfType<ContainerImageAnnotation>().LastOrDefault();
+                if (imageAnnotation is null)
+                {
+                    // Defensive: AddDocumentDB sets ContainerImageAnnotation eagerly via WithImage.
+                    return Task.CompletedTask;
+                }
+
+                var logger = TryGetResourceLogger(evt);
+
+                // Custom-image carve-out: only enforce the floor on the curated
+                // documentdb-local image. A fork using a different image name
+                // (regardless of registry) is assumed to know what it is doing.
+                if (!string.Equals(imageAnnotation.Image, DocumentDBContainerImageTags.Image, StringComparison.Ordinal))
+                {
+                    if (Interlocked.CompareExchange(ref warningLogged, 1, 0) == 0)
+                    {
+                        logger?.LogWarning(
+                            "DocumentDB resource '{ResourceName}' uses custom image '{Image}:{Tag}'. " +
+                            "The v{MinVersion} minimum required by WithPostgresEndpoint() for credential parity " +
+                            "is NOT enforced on custom images.",
+                            evt.Resource.Name,
+                            imageAnnotation.Image,
+                            imageAnnotation.Tag,
+                            DocumentDBContainerImageTags.MinimumPostgresEndpointVersion);
+                    }
+                    return Task.CompletedTask;
+                }
+
+                if (!DocumentDBContainerImageTags.TryParseDocumentDBTag(imageAnnotation.Tag, out _, out var docVersion))
+                {
+                    if (Interlocked.CompareExchange(ref warningLogged, 1, 0) == 0)
+                    {
+                        logger?.LogWarning(
+                            "DocumentDB resource '{ResourceName}' uses image tag '{Tag}', which does not match " +
+                            "the curated 'pg{{NN}}-X.Y.Z' pattern. The v{MinVersion} minimum required by " +
+                            "WithPostgresEndpoint() for credential parity is NOT enforced on unrecognised tags.",
+                            evt.Resource.Name,
+                            imageAnnotation.Tag,
+                            DocumentDBContainerImageTags.MinimumPostgresEndpointVersion);
+                    }
+                    return Task.CompletedTask;
+                }
+
+                if (docVersion < DocumentDBContainerImageTags.MinimumPostgresEndpointVersion)
+                {
+                    throw new InvalidOperationException(
+                        $"DocumentDB resource '{evt.Resource.Name}' is configured with image tag " +
+                        $"'{imageAnnotation.Tag}', but WithPostgresEndpoint() requires DocumentDB " +
+                        $"v{DocumentDBContainerImageTags.MinimumPostgresEndpointVersion} or later. " +
+                        $"Earlier images hard-code the PostgreSQL admin credentials to " +
+                        $"'docdb_admin'/'Admin100', so the Aspire-generated postgresql:// connection " +
+                        $"string would silently fail to authenticate. Recovery: chain " +
+                        $"'.WithImageTag(\"pg{{NN}}-{DocumentDBContainerImageTags.MinimumPostgresEndpointVersion}\")' " +
+                        $"(or newer) after AddDocumentDB(...). See " +
+                        $"https://github.com/microsoft/azure-databases-aspire/issues/71.");
+                }
+
+                return Task.CompletedTask;
             });
+
+        return builder;
+    }
+
+    private static ILogger? TryGetResourceLogger(BeforeResourceStartedEvent evt)
+    {
+        // Prefer per-resource logger so the message shows in the Aspire dashboard's
+        // resource log pane. Fall back to a general host logger if the service is
+        // not registered (shouldn't happen in 13.3.5, but defensive).
+        var resourceLoggerService = evt.Services.GetService<ResourceLoggerService>();
+        if (resourceLoggerService is not null)
+        {
+            return resourceLoggerService.GetLogger(evt.Resource);
+        }
+
+        var loggerFactory = evt.Services.GetService<ILoggerFactory>();
+        return loggerFactory?.CreateLogger("Aspire.Hosting.DocumentDB.WithPostgresEndpoint");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.DocumentDB/DocumentDBContainerImageTags.cs
+++ b/src/Aspire.Hosting.DocumentDB/DocumentDBContainerImageTags.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.DocumentDB;
 
-internal static class DocumentDBContainerImageTags
+internal static partial class DocumentDBContainerImageTags
 {
     /// <remarks>ghcr.io/documentdb</remarks>
     public const string Registry = "ghcr.io/documentdb";
@@ -19,4 +21,78 @@ internal static class DocumentDBContainerImageTags
     /// being baked in at compile time as a <see langword="const"/>.
     /// </summary>
     public static string Tag => $"pg{(int)DocumentDBPostgresVersion.Pg17}-{DocumentDBVersions.Latest}";
+
+    /// <summary>
+    /// The earliest <c>documentdb-local</c> DocumentDB version whose entrypoint passes
+    /// the gateway-supplied <c>USERNAME</c>/<c>PASSWORD</c> through to PostgreSQL admin-user
+    /// creation. On older images the entrypoint hard-codes <c>docdb_admin</c>/<c>Admin100</c>,
+    /// so the Aspire-generated <c>postgresql://</c> connection string silently fails
+    /// authentication. <see cref="Aspire.Hosting.DocumentDBBuilderExtensions.WithPostgresEndpoint"/>
+    /// uses this floor at startup to convert that silent failure into a loud
+    /// <see cref="InvalidOperationException"/>.
+    /// </summary>
+    internal static readonly Version MinimumPostgresEndpointVersion = new(0, 112, 0);
+
+    // Anchored (^ ... \z, NOT $ which also matches before a final \n) and ASCII-only
+    // ([0-9] not \d, so unicode-digit categories cannot slip through). Case-insensitive
+    // on the "pg" prefix only. Requires exactly three numeric version segments; any
+    // trailing pre-release ("-rc.1") or build-metadata ("+abc") suffix causes the match
+    // to fail, so such tags are treated as "unknown" by callers (warn + skip) rather
+    // than silently passing the version floor.
+    [GeneratedRegex(@"^[pP][gG](?<pg>[0-9]+)-(?<v>[0-9]+\.[0-9]+\.[0-9]+)\z", RegexOptions.CultureInvariant)]
+    private static partial Regex DocumentDBTagRegex();
+
+    /// <summary>
+    /// Attempts to parse a <c>documentdb-local</c> container image tag of the
+    /// form <c>pg{NN}-X.Y.Z</c> (e.g., <c>pg17-0.112.0</c>) into its PostgreSQL
+    /// major version and the DocumentDB semantic version.
+    /// </summary>
+    /// <param name="tag">The container image tag to parse. May be <see langword="null"/>.</param>
+    /// <param name="pg">The PostgreSQL major version (e.g., <c>17</c>) on success.</param>
+    /// <param name="docVersion">The DocumentDB semantic version (e.g., <c>0.112.0</c>) on success.</param>
+    /// <returns>
+    /// <see langword="true"/> if the tag matches the strict <c>pg{NN}-X.Y.Z</c> grammar.
+    /// <see langword="false"/> for <see langword="null"/>, empty/whitespace, two-part
+    /// versions (e.g., <c>pg17-0.112</c>), pre-release/build-metadata suffixes
+    /// (e.g., <c>pg17-0.112.0-rc.1</c>), missing prefix (e.g., <c>0.112.0</c>),
+    /// or any other custom/unrecognised tag (e.g., <c>latest</c>, <c>nightly</c>).
+    /// Callers should treat <see langword="false"/> as "unknown — do not enforce
+    /// version-floor policy" rather than as a failed assertion.
+    /// </returns>
+    internal static bool TryParseDocumentDBTag(
+        string? tag,
+        out int pg,
+        [NotNullWhen(true)] out Version? docVersion)
+    {
+        pg = 0;
+        docVersion = null;
+
+        if (string.IsNullOrWhiteSpace(tag))
+        {
+            return false;
+        }
+
+        var match = DocumentDBTagRegex().Match(tag);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        // The regex constrains both groups to ASCII digits, but int.TryParse still
+        // protects against integer overflow on absurdly long pg-major strings (e.g.,
+        // "pg99999999999999999999-0.112.0").
+        if (!int.TryParse(match.Groups["pg"].ValueSpan, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var pgParsed))
+        {
+            return false;
+        }
+
+        if (!Version.TryParse(match.Groups["v"].ValueSpan, out var parsedVersion))
+        {
+            return false;
+        }
+
+        pg = pgParsed;
+        docVersion = parsedVersion;
+        return true;
+    }
 }

--- a/tests/Aspire.Hosting.DocumentDB.PostgresEndToEndApp/Aspire.Hosting.DocumentDB.PostgresEndToEndApp.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.PostgresEndToEndApp/Aspire.Hosting.DocumentDB.PostgresEndToEndApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Aspire.AppHost.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.DocumentDB\Aspire.Hosting.DocumentDB.csproj" IsAspireProjectResource="false" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.DocumentDB.PostgresEndToEndApp/Program.cs
+++ b/tests/Aspire.Hosting.DocumentDB.PostgresEndToEndApp/Program.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting;
+
+namespace Aspire.Hosting.DocumentDB.PostgresEndToEndApp;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+
+        // Pin to pg17-0.112.0 explicitly so this AppHost does not depend on
+        // DocumentDBVersions.Latest being bumped to >= 0.112.0 (tracked by issue
+        // #70). The v0.112-0 floor is enforced by WithPostgresEndpoint() itself;
+        // see https://github.com/microsoft/azure-databases-aspire/issues/71.
+        builder.AddDocumentDB("documentdb")
+            .WithImageTag("pg17-0.112.0")
+            .WithPostgresEndpoint();
+
+        var app = builder.Build();
+
+        await app.RunAsync();
+    }
+}

--- a/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/AddDocumentDBTest.cs
@@ -3,9 +3,11 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -946,6 +948,304 @@ public class AddDocumentDBTests
 
         var env = await BuildEnvironmentVariablesAsync(containerResource);
         Assert.False(env.ContainsKey("ALLOW_EXTERNAL_CONNECTIONS"));
+    }
+
+    // ---------------------------------------------------------------------
+    // WithPostgresEndpoint() v0.112.0 floor guard (issue #71)
+    //
+    // The guard is implemented via a BeforeResourceStartedEvent subscription
+    // so that callers chaining WithImageTag(...) AFTER WithPostgresEndpoint()
+    // still get validated against the final effective tag. These tests publish
+    // BeforeResourceStartedEvent synthetically so they stay pure unit tests
+    // (no Docker, no real app StartAsync).
+    // ---------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("pg17-0.112.0")]
+    [InlineData("pg17-0.113.0")]
+    [InlineData("pg17-1.0.0")]
+    [InlineData("pg15-0.112.0")]
+    [InlineData("pg16-0.200.0")]
+    public async Task WithPostgresEndpointAllowsV0_112_0AndAbove(string tag)
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithImageTag(tag)
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        await PublishBeforeResourceStartedAsync(app, resource);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointWithImageTagV0_111_0Throws()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithImageTag("pg17-0.111.0")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PublishBeforeResourceStartedAsync(app, resource));
+
+        Assert.Contains("DocumentDB", ex.Message);
+        Assert.Contains("pg17-0.111.0", ex.Message);
+        Assert.Contains("0.112.0", ex.Message);
+        Assert.Contains("WithPostgresEndpoint", ex.Message);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointWithDocumentDBVersionV0_111_0Throws()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithDocumentDBVersion(DocumentDBVersion.V0_111_0)
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PublishBeforeResourceStartedAsync(app, resource));
+
+        Assert.Contains("pg17-0.111.0", ex.Message);
+        Assert.Contains("0.112.0", ex.Message);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointWithUnknownTagPatternLogsWarningOnceAndAllows()
+    {
+        var sink = new CapturingLoggerSink();
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Services.AddSingleton<ILoggerProvider>(new CapturingLoggerProvider(sink));
+
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithImageTag("nightly")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        // Publish the event TWICE to prove the warning is one-shot.
+        await PublishBeforeResourceStartedAsync(app, resource, useEmptyServices: true);
+        await PublishBeforeResourceStartedAsync(app, resource, useEmptyServices: true);
+
+        var warnings = sink.LogEntries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.Single(warnings);
+        Assert.Contains("nightly", warnings[0].Message);
+        Assert.Contains("pg{NN}-X.Y.Z", warnings[0].Message);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointGuardHonoursLastCallWins()
+    {
+        // WithImageTag chained AFTER WithPostgresEndpoint must still be detected,
+        // because the guard reads the effective ContainerImageAnnotation at event time,
+        // not at WithPostgresEndpoint() call time.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint()
+            .WithImageTag("pg17-0.111.0");
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PublishBeforeResourceStartedAsync(app, resource));
+
+        Assert.Contains("pg17-0.111.0", ex.Message);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointGuardSkippedForCustomImage()
+    {
+        // A fork using a non-curated image name is exempt with a warning.
+        var sink = new CapturingLoggerSink();
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Services.AddSingleton<ILoggerProvider>(new CapturingLoggerProvider(sink));
+
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithImage("forks/my-build", "pg17-0.110.0")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        // Must NOT throw, even though the tag is < v0.112.0.
+        await PublishBeforeResourceStartedAsync(app, resource, useEmptyServices: true);
+        await PublishBeforeResourceStartedAsync(app, resource, useEmptyServices: true);
+
+        var warnings = sink.LogEntries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.Single(warnings);
+        Assert.Contains("custom image", warnings[0].Message);
+        Assert.Contains("forks/my-build", warnings[0].Message);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointGuardSkippedForCustomImageWithCustomRegistry()
+    {
+        // Confirm that ContainerImageAnnotation.Registry does NOT factor into the
+        // image-name carve-out: the curated image hosted on a private registry is
+        // still subject to the guard, while a custom image is exempt regardless of
+        // registry.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithImage("forks/my-build", "pg17-0.110.0")
+            .WithImageRegistry("registry.example.com")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        // Must NOT throw.
+        await PublishBeforeResourceStartedAsync(app, resource);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointGuardEnforcedWhenOnlyRegistryOverridden()
+    {
+        // Mirror image: a private mirror of the curated documentdb-local image MUST
+        // still be guarded - only the image NAME exempts, not the registry.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithImageRegistry("registry.example.com")
+            .WithImageTag("pg17-0.111.0")
+            .WithPostgresEndpoint();
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PublishBeforeResourceStartedAsync(app, resource));
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointDefaultTagThrowsUntilLatestReachesV0_112_0()
+    {
+        // Documents the intentional behavior described in issue #71's docs callout:
+        // when DocumentDBVersions.Latest is < 0.112.0, AddDocumentDB().WithPostgresEndpoint()
+        // (no explicit tag override) will throw at startup. This is the whole point of
+        // the issue - converting a silent auth failure into a loud one. Once issue #70
+        // bumps Latest to >= 0.112.0, this test's branch becomes the "no-throw" path.
+        var latestParsed = Version.Parse(DocumentDBVersions.Latest);
+        var floor = DocumentDBContainerImageTags.MinimumPostgresEndpointVersion;
+
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint(); // intentionally no WithImageTag
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        if (latestParsed < floor)
+        {
+            // Current branch: Latest is 0.111.0, guard throws.
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => PublishBeforeResourceStartedAsync(app, resource));
+            Assert.Contains($"pg17-{DocumentDBVersions.Latest}", ex.Message);
+        }
+        else
+        {
+            // After #70 lands: Latest is >= 0.112.0, default flow succeeds.
+            await PublishBeforeResourceStartedAsync(app, resource);
+        }
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointGuardDoesNotFireDuringManifestGeneration()
+    {
+        // Manifest generation goes through Aspire's publish pipeline, which does NOT
+        // publish BeforeResourceStartedEvent (no container is started). The guard must
+        // not interfere with `azd publish` / `--publisher manifest` flows, even when
+        // pinning a pre-v0.112 tag.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var documentDB = appBuilder.AddDocumentDB("DocumentDB")
+            .WithImageTag("pg17-0.111.0")
+            .WithPostgresEndpoint();
+
+        // Generating the manifest must not throw.
+        var manifest = await ManifestUtils.GetManifest(documentDB.Resource);
+
+        Assert.NotNull(manifest);
+        var bindings = manifest["bindings"];
+        Assert.NotNull(bindings);
+        Assert.NotNull(bindings!["postgres"]);
+    }
+
+    [Fact]
+    public async Task WithPostgresEndpointGuardReadsLastWithImageTagCall()
+    {
+        // Multiple WithImageTag calls: the LAST one wins (Aspire mutates the single
+        // ContainerImageAnnotation in place). The guard must observe the final value,
+        // not an intermediate one.
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.AddDocumentDB("DocumentDB")
+            .WithPostgresEndpoint()
+            .WithImageTag("pg17-0.111.0")  // would throw...
+            .WithImageTag("pg17-0.112.0"); // ...but this overrides.
+
+        using var app = appBuilder.Build();
+        var resource = Assert.Single(app.Services.GetRequiredService<DistributedApplicationModel>().Resources.OfType<DocumentDBServerResource>());
+
+        // Must NOT throw - the final tag is >= floor.
+        await PublishBeforeResourceStartedAsync(app, resource);
+    }
+
+    private static Task PublishBeforeResourceStartedAsync(DistributedApplication app, IResource resource, bool useEmptyServices = false)
+    {
+        var eventing = app.Services.GetRequiredService<IDistributedApplicationEventing>();
+        // useEmptyServices=true forces the guard's logger-resolution fallback path
+        // (ILoggerFactory) instead of ResourceLoggerService. This lets tests
+        // capture the warning text via a CapturingLoggerProvider registered on the
+        // app's service collection, without needing to inspect ResourceLoggerService's
+        // internal per-resource log buffer.
+        var services = useEmptyServices
+            ? new ServiceCollection().AddSingleton(app.Services.GetRequiredService<ILoggerFactory>()).BuildServiceProvider()
+            : app.Services;
+        var evt = new BeforeResourceStartedEvent(resource, services);
+        return eventing.PublishAsync(evt, EventDispatchBehavior.BlockingSequential, CancellationToken.None);
+    }
+
+    private sealed class CapturingLoggerSink
+    {
+        public List<(LogLevel Level, string Category, string Message)> LogEntries { get; } = new();
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly CapturingLoggerSink _sink;
+        public CapturingLoggerProvider(CapturingLoggerSink sink) => _sink = sink;
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_sink, categoryName);
+        public void Dispose() { }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly CapturingLoggerSink _sink;
+            private readonly string _category;
+            public CapturingLogger(CapturingLoggerSink sink, string category)
+            {
+                _sink = sink;
+                _category = category;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                _sink.LogEntries.Add((logLevel, _category, formatter(state, exception)));
+            }
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj
@@ -9,9 +9,11 @@
     <ProjectReference Include="..\Aspire.Hosting.DocumentDB.EndToEndApp\Aspire.Hosting.DocumentDB.EndToEndApp.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp\Aspire.Hosting.DocumentDB.ConfiguredEndToEndApp.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp\Aspire.Hosting.DocumentDB.AdvancedConfigEndToEndApp.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.DocumentDB.PostgresEndToEndApp\Aspire.Hosting.DocumentDB.PostgresEndToEndApp.csproj" />
     <PackageReference Include="Aspire.MongoDB.Driver" />
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Npgsql" />
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="xunit" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBContainerImageTagsTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBContainerImageTagsTests.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Hosting.DocumentDB.Tests;
+
+[Trait("Category", "Unit")]
+public class DocumentDBContainerImageTagsTests
+{
+    [Fact]
+    public void MinimumPostgresEndpointVersionIs_0_112_0()
+    {
+        Assert.Equal(new Version(0, 112, 0), DocumentDBContainerImageTags.MinimumPostgresEndpointVersion);
+    }
+
+    [Theory]
+    // Happy path - all three supported PG variants.
+    [InlineData("pg15-0.112.0", 15, "0.112.0")]
+    [InlineData("pg16-0.112.0", 16, "0.112.0")]
+    [InlineData("pg17-0.112.0", 17, "0.112.0")]
+    // Other valid release versions.
+    [InlineData("pg17-0.109.0", 17, "0.109.0")]
+    [InlineData("pg17-0.111.0", 17, "0.111.0")]
+    [InlineData("pg17-1.0.0", 17, "1.0.0")]
+    [InlineData("pg17-1.2.3", 17, "1.2.3")]
+    [InlineData("pg17-10.20.30", 17, "10.20.30")]
+    // Case-insensitive on "pg" prefix only.
+    [InlineData("PG17-0.112.0", 17, "0.112.0")]
+    [InlineData("Pg17-0.112.0", 17, "0.112.0")]
+    [InlineData("pG17-0.112.0", 17, "0.112.0")]
+    // Single-digit and multi-digit PG majors are both accepted (\d+).
+    [InlineData("pg9-0.112.0", 9, "0.112.0")]
+    [InlineData("pg175-0.112.0", 175, "0.112.0")]
+    public void TryParseDocumentDBTagAcceptsStrictPgNNVersion(string tag, int expectedPg, string expectedVersion)
+    {
+        var ok = DocumentDBContainerImageTags.TryParseDocumentDBTag(tag, out var pg, out var docVersion);
+
+        Assert.True(ok, $"expected '{tag}' to parse");
+        Assert.Equal(expectedPg, pg);
+        Assert.NotNull(docVersion);
+        Assert.Equal(Version.Parse(expectedVersion), docVersion);
+    }
+
+    [Theory]
+    // Null / empty / whitespace-only.
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    // Whitespace at edges must NOT parse (strict).
+    [InlineData(" pg17-0.112.0")]
+    [InlineData("pg17-0.112.0 ")]
+    [InlineData(" pg17-0.112.0 ")]
+    // Trailing newline must NOT slip past the anchor (\z is used, not $).
+    [InlineData("pg17-0.112.0\n")]
+    [InlineData("pg17-0.112.0\r\n")]
+    // Two-part version - rejected to avoid the System.Version.Build=-1 comparison bug.
+    [InlineData("pg17-0.112")]
+    [InlineData("pg17-1.0")]
+    // Pre-release / build-metadata suffixes - rejected because System.Version cannot
+    // represent them and we MUST NOT silently allow an rc/alpha to pass the floor.
+    [InlineData("pg17-0.112.0-rc.1")]
+    [InlineData("pg17-0.112.0-alpha")]
+    [InlineData("pg17-0.112.0+build.42")]
+    [InlineData("pg17-0.112.0-rc1+meta")]
+    // Missing "pg" prefix.
+    [InlineData("0.112.0")]
+    [InlineData("17-0.112.0")]
+    // "pg" without numeric major.
+    [InlineData("pg-0.112.0")]
+    [InlineData("pgX-0.112.0")]
+    // Non-numeric version segments.
+    [InlineData("pg17-foo")]
+    [InlineData("pg17-latest")]
+    [InlineData("pg17-0.x.0")]
+    // Wrong separator between pg-prefix and version.
+    [InlineData("pg17_0.112.0")]
+    [InlineData("pg170.112.0")]
+    [InlineData("pg17.0.112.0")]
+    // Custom-image-style tags.
+    [InlineData("latest")]
+    [InlineData("nightly")]
+    [InlineData("sha256-deadbeef")]
+    // Four-part version (Revision) - rejected (strict 3-segment grammar).
+    [InlineData("pg17-0.112.0.1")]
+    // Unicode-digit categories must NOT match (regex uses [0-9], not \d).
+    [InlineData("pg\u0661\u0667-0.112.0")] // pg with Arabic-Indic 17
+    [InlineData("pg17-\u0660.112.0")]      // Arabic-Indic 0 in version
+    public void TryParseDocumentDBTagRejectsUnknownPatterns(string? tag)
+    {
+        var ok = DocumentDBContainerImageTags.TryParseDocumentDBTag(tag, out var pg, out var docVersion);
+
+        Assert.False(ok, $"expected '{tag ?? "<null>"}' to NOT parse");
+        Assert.Equal(0, pg);
+        Assert.Null(docVersion);
+    }
+
+    [Theory]
+    // Above the floor.
+    [InlineData("pg17-0.112.0", false)]
+    [InlineData("pg17-0.113.0", false)]
+    [InlineData("pg17-0.200.0", false)]
+    [InlineData("pg17-1.0.0", false)]
+    [InlineData("pg15-0.112.0", false)]
+    // Below the floor.
+    [InlineData("pg17-0.111.0", true)]
+    [InlineData("pg17-0.109.0", true)]
+    [InlineData("pg17-0.0.1", true)]
+    [InlineData("pg15-0.111.0", true)]
+    public void ParsedVersionComparesCorrectlyAgainstMinimumPostgresEndpointVersion(string tag, bool expectedBelowFloor)
+    {
+        Assert.True(DocumentDBContainerImageTags.TryParseDocumentDBTag(tag, out _, out var docVersion));
+        var isBelow = docVersion < DocumentDBContainerImageTags.MinimumPostgresEndpointVersion;
+        Assert.Equal(expectedBelowFloor, isBelow);
+    }
+}

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBIntegrationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using Npgsql;
 using Xunit;
 using Xunit.Sdk;
 
@@ -173,6 +174,122 @@ public class DocumentDBIntegrationTests
 
         await collection.InsertOneAsync(document, cancellationToken: cts.Token);
         Assert.Equal(1, await collection.CountDocumentsAsync(filter, cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task PostgresConnectionStringResolvesAndAuthenticatesAgainstContainer()
+    {
+        // Regression for issue #71: prior to v0.112-0, the documentdb-local entrypoint
+        // hard-coded the PostgreSQL admin role to docdb_admin/Admin100, so the
+        // postgresql:// connection string Aspire produces (which uses the gateway's
+        // USERNAME/PASSWORD) silently failed authentication. v0.112-0 makes the
+        // entrypoint honour USERNAME/PASSWORD on the PG admin role. This test pins
+        // the fix end-to-end: opening an Npgsql connection with the Aspire-resolved
+        // credentials must succeed, and current_user must report 'admin' (NOT the
+        // legacy docdb_admin).
+        //
+        // The AppHost (Aspire.Hosting.DocumentDB.PostgresEndToEndApp) pins the
+        // image to pg17-0.112.0 explicitly so the test does not depend on
+        // DocumentDBVersions.Latest being bumped to >= 0.112.0 (tracked by #70).
+        if (!RequiresDockerAttribute.IsSupported)
+        {
+            throw SkipException.ForSkip("Docker is required for DocumentDB end-to-end validation.");
+        }
+
+        using var cts = CreateEndToEndTimeoutSource();
+
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Aspire.Hosting.DocumentDB.PostgresEndToEndApp.Program>(cts.Token);
+        await using var app = await appHost.BuildAsync(cts.Token);
+        await app.StartAsync(cts.Token);
+
+        var healthCheckService = app.Services.GetRequiredService<HealthCheckService>();
+        await WaitForHealthCheckAsync(healthCheckService, "documentdb_check", cts.Token);
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var documentDB = Assert.Single(appModel.Resources.OfType<DocumentDBServerResource>());
+        var connectionString = await documentDB.PostgresConnectionStringExpression.GetValueAsync(cts.Token);
+        Assert.False(string.IsNullOrWhiteSpace(connectionString));
+
+        // PostgreSQL backend may take a moment to come up after the MongoDB gateway
+        // is healthy; retry mirroring the Mongo ConnectAsync pattern above.
+        var (selectOneResult, currentUser) = await OpenPostgresAndRunSmokeTestsAsync(connectionString!, cts.Token);
+
+        Assert.Equal(1, selectOneResult);
+        Assert.Equal("admin", currentUser);
+    }
+
+    private static async Task<(int SelectOneResult, string CurrentUser)> OpenPostgresAndRunSmokeTestsAsync(
+        string postgresqlUri,
+        CancellationToken cancellationToken)
+    {
+        // Npgsql (verified against 9.0.5) does NOT parse postgresql:// URIs: both
+        // NpgsqlConnectionStringBuilder(uri) and new NpgsqlConnection(uri) throw
+        // ArgumentException at construct time. Convert the URI to key-value form.
+        var keyValueConnectionString = ConvertPostgresUriToKeyValue(postgresqlUri);
+
+        Exception? lastException = null;
+
+        for (var attempt = 0; attempt < 15; attempt++)
+        {
+            try
+            {
+                await using var conn = new NpgsqlConnection(keyValueConnectionString);
+                await conn.OpenAsync(cancellationToken);
+
+                await using var selectOne = new NpgsqlCommand("SELECT 1", conn);
+                var selectOneResult = Convert.ToInt32(await selectOne.ExecuteScalarAsync(cancellationToken));
+
+                await using var currentUser = new NpgsqlCommand("SELECT current_user", conn);
+                var currentUserResult = (string)(await currentUser.ExecuteScalarAsync(cancellationToken))!;
+
+                return (selectOneResult, currentUserResult);
+            }
+            catch (NpgsqlException ex)
+            {
+                lastException = ex;
+            }
+            catch (SocketException ex)
+            {
+                lastException = ex;
+            }
+            catch (TimeoutException ex)
+            {
+                lastException = ex;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+
+        throw new InvalidOperationException(
+            "PostgreSQL did not become reachable / did not authenticate the Aspire-resolved credentials in time. " +
+            "If this fails with '28P01: password authentication failed', the documentdb-local image is older " +
+            "than v0.112-0, in which case WithPostgresEndpoint() should have blocked startup.",
+            lastException);
+    }
+
+    /// <summary>
+    /// Converts a <c>postgresql://user:password@host:port/database</c> URI (the form
+    /// emitted by <see cref="DocumentDBServerResource.PostgresConnectionStringExpression"/>)
+    /// into the key=value form that Npgsql 9.x requires.
+    /// </summary>
+    private static string ConvertPostgresUriToKeyValue(string postgresqlUri)
+    {
+        var uri = new Uri(postgresqlUri);
+        var userInfo = uri.UserInfo.Split(':', 2);
+        var user = Uri.UnescapeDataString(userInfo[0]);
+        var password = userInfo.Length > 1 ? Uri.UnescapeDataString(userInfo[1]) : string.Empty;
+        var database = uri.AbsolutePath.TrimStart('/');
+
+        return new NpgsqlConnectionStringBuilder
+        {
+            Host = uri.Host,
+            Port = uri.Port,
+            Username = user,
+            Password = password,
+            Database = string.IsNullOrEmpty(database) ? "postgres" : database,
+            Timeout = 5,
+            CommandTimeout = 5,
+        }.ConnectionString;
     }
 
     private static async Task<IMongoDatabase> ConnectAsync(string connectionString, string databaseName, CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #71.

## Problem

`WithPostgresEndpoint()` (added in #69) publishes the PostgreSQL coordinator port and surfaces a `postgresql://admin:<password>@host:port/postgres` connection string that uses the gateway's `USERNAME`/`PASSWORD`. On `documentdb-local` images before `v0.112-0`, the entrypoint hard-codes the PostgreSQL admin role to `docdb_admin`/`Admin100` (see `documentdb-local/scripts/emulator_entrypoint.sh` pre-`v0.112-0`), so the generated URI **silently fails authentication**. v0.112-0 fixed the entrypoint to honour `USERNAME`/`PASSWORD` for the PG admin role.

This PR converts the silent failure into a loud startup-time `InvalidOperationException`.

## What this PR ships

### Guard

- `DocumentDBContainerImageTags.MinimumPostgresEndpointVersion = new(0, 112, 0)` (internal).
- `DocumentDBContainerImageTags.TryParseDocumentDBTag(string? tag, out int pg, out Version? docVersion)` (internal), using a strict anchored regex `^[pP][gG][0-9]+-[0-9]+\.[0-9]+\.[0-9]+\z`. Pre-release suffixes, build-metadata suffixes, two-part versions (which would trip `System.Version`'s `Build = -1` comparison bug), trailing newline/whitespace, and unicode-digit categories all return `false`.
- `WithPostgresEndpoint()` subscribes a `BeforeResourceStartedEvent` handler so the validation honours **last-call-wins** — `WithImageTag(...)` chained AFTER `WithPostgresEndpoint()` still gets validated.

### Behaviour matrix

| Effective image                                         | Tag                 | Result                                                                                |
| ------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------- |
| `documentdb/documentdb-local`                           | `pg17-0.112.0` or newer | OK                                                                                |
| `documentdb/documentdb-local`                           | `pg17-0.111.0` or older | **Throws `InvalidOperationException`** with resource name + tag + recovery recipe |
| `documentdb/documentdb-local`                           | `latest`, `nightly`, `pg17-0.112.0-rc.1`, other unrecognised | One-shot warning, no throw                       |
| Any non-curated image (e.g., `forks/my-build:pg17-0.110.0`) | any              | One-shot warning, no throw                                                            |
| Same as above but in publish/manifest mode             | any                 | Guard does not fire (no container is being started)                                   |

The custom-image carve-out keys on **image name** only (`documentdb/documentdb-local`), so a private mirror of the curated image on a custom registry IS still guarded — a `WithImageRegistry(...)` override alone does not bypass.

### Tests

| Suite | Count | Coverage |
| --- | --- | --- |
| `DocumentDBContainerImageTagsTests` (new file) | 51 theory cases | Parser happy-path for all three PG variants and version ranges; rejects two-part, pre-release, build-metadata, trailing newline/whitespace, unicode digits, missing prefix, wrong separator, single/multi-digit pg major. |
| `AddDocumentDBTest` (new guard tests) | 13 | Allowed-above-floor theory, V111 throws via `WithImageTag` and `WithDocumentDBVersion`, unknown-tag warns exactly once, last-call-wins (both directions), custom-image carve-out, custom-registry mirror still guarded, **default-tag-throws-until-Latest-bumped** (pins #70's transition), **does-not-fire-during-manifest-generation**, multiple `WithImageTag` calls — last wins. |
| `DocumentDBIntegrationTests.PostgresConnectionStringResolvesAndAuthenticatesAgainstContainer` (new test, Docker-gated) | 1 | Uses a new sub-project `Aspire.Hosting.DocumentDB.PostgresEndToEndApp` pinned to `pg17-0.112.0`. Opens an Npgsql connection (URI → key-value conversion because Npgsql 9.x does not accept `postgresql://` URIs), runs `SELECT 1` AND `SELECT current_user` to confirm the role is `admin` (NOT the legacy `docdb_admin`). |

**Unit suite: 178 / 178 pass. Build: 0 warnings / 0 errors.**

### Docs + changelog

- `docs/configuration.md`: a `> [!IMPORTANT]` callout under `## WithPostgresEndpoint` quotes the exception message, shows the `.WithImageTag("pg17-0.112.0")` recovery recipe, and explicitly documents the run-mode-only / curated-image-only scope of the guard.
- `CHANGELOG.md`: a new `[Unreleased] -> ### Fixed` entry plus an amendment to the existing `### Added` `WithPostgresEndpoint()` line so cross-section readers see the v0.112 requirement either way.

### Dependencies

- `Npgsql 9.0.5` added to `Directory.Packages.props` and the test project (central package management).
- New sub-project `tests/Aspire.Hosting.DocumentDB.PostgresEndToEndApp/` registered in the solution.

## Scope decision

This PR **does not bundle #70** (the `V0_112_0` enum bump). The issue explicitly says "Implement after #70 lands," and #70's auto-generated marker blocks are owned by `check-documentdb-version.yml`. As a result, on this branch alone `DocumentDBVersions.Latest == "0.111.0"` and the default-flow `AddDocumentDB(...).WithPostgresEndpoint()` will throw at startup. **That is the intended behaviour** of this issue — turn a silent auth failure into a loud one. Once #70 lands, `WithPostgresEndpointDefaultTagThrowsUntilLatestReachesV0_112_0` automatically flips to the no-throw branch.

The recovery recipe is documented in the new docs callout:

```csharp
var db = builder.AddDocumentDB("documentdb")
                .WithImageTag("pg17-0.112.0")   // or any newer tag
                .WithPostgresEndpoint();
```

## Process

The plan and implementation each went through a parallel **5-agent code review** (gpt-5.4, gpt-5.5, opus-4.6, opus-4.7, opus-4.8). Key findings adopted:

- **Strict parser anchors** (`\z` instead of `$`, `[0-9]` instead of `\d`) so the regex is literally strict about trailing newlines and unicode-digit categories.
- **Exception text dropped the `WithDocumentDBVersion(DocumentDBVersion.V0_112_0)` suggestion** since the enum member does not exist on this branch (cited by 4 of 5 reviewers).
- **Npgsql URI parsing**: empirically reproduced that `NpgsqlConnectionStringBuilder("postgresql://...")` and `new NpgsqlConnection("postgresql://...")` both throw `ArgumentException` in Npgsql 9.x. Integration test now parses the URI and constructs the connection in key-value form.
- **Integration test moved to a sub-project AppHost**: `DistributedApplicationTestingBuilder.Create(args)` requires an AppHost assembly; inline usage threw `InvalidOperationException: No application host assembly was found`. Now matches the existing `EndToEndApp`/`ConfiguredEndToEndApp`/`AdvancedConfigEndToEndApp` pattern.
- **`Interlocked.CompareExchange` for the one-shot warning flag**, so the at-most-once property is memory-safe if a future Aspire orchestrator ever dispatches the event concurrently for the same resource.

## Validation

```
$ dotnet build
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet test --filter "Category=Unit"
Passed!  - Failed: 0, Passed: 178, Skipped: 0, Total: 178
```

Integration test is gated behind `RequiresDockerAttribute.IsSupported` and exercises the real `pg17-0.112.0` container.
