### PR TITLE
Bump Aspire to 13.4.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,23 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
   </ItemGroup>
 
-  <!-- Pin transitive dependencies to resolve known vulnerabilities -->
+  <!--
+    Transitive dependencies pulled in through the MongoDB.Driver chain, pinned to
+    non-vulnerable, restore-compatible versions. Keep these until the advisories
+    below no longer apply to the resolved graph.
+
+    SharpCompress 1.0.0:
+      * Minimum floor mandated by Aspire.MongoDB.Driver 13.4.2 (its nuspec requires
+        SharpCompress >= 1.0.0), so a lower pin fails restore with NU1109. This is the
+        lowest version that satisfies both upstream and the advisory below; it is
+        intentionally not a 0.4x pin.
+      * Clears GHSA-6c8g-7p36-r338 (zip-slip directory traversal, medium; affects
+        <= 0.47.4). Without this pin, MongoDB.Driver 3.8.1 alone would floor
+        SharpCompress at 0.30.1 (vulnerable).
+    Snappier 1.3.1:
+      * Clears GHSA-pggp-6c3x-2xmx (decompression infinite-loop DoS, high; affects
+        <= 1.3.0).
+  -->
   <ItemGroup Label="Transitive pins">
     <PackageVersion Include="SharpCompress" Version="1.0.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,29 +5,29 @@
   </PropertyGroup>
 
   <ItemGroup Label="Production">
-    <PackageVersion Include="Aspire.Hosting" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.3.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="13.4.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
   </ItemGroup>
 
   <!-- Pin transitive dependencies to resolve known vulnerabilities -->
   <ItemGroup Label="Transitive pins">
-    <PackageVersion Include="SharpCompress" Version="0.48.0" />
+    <PackageVersion Include="SharpCompress" Version="1.0.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Label="Test-only">
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />

--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
     "allowPrerelease": false
   },
   "msbuild-sdks": {
-    "Aspire.AppHost.Sdk": "13.3.5"
+    "Aspire.AppHost.Sdk": "13.4.2"
   }
 }


### PR DESCRIPTION
Bumps `Aspire.AppHost.Sdk` from 13.3.5 to 13.4.2 in `global.json` and updates the centrally managed Aspire and `Microsoft.Extensions.*` package versions in `Directory.Packages.props` to keep them in sync.

## Why
The Aspire AppHost SDK implicitly references `Aspire.Hosting.AppHost` at the same version (13.4.2), which transitively requires higher package versions than the ones pinned via Central Package Management. Bumping only the SDK (as Dependabot did) leaves the CPM versions stale and produces `NU1109` package-downgrade errors at restore.

This is the same fix pattern as #66 ("Bump Aspire to 13.3.5"), and **supersedes the Dependabot PR #82**, which only bumped the SDK in `global.json` and left the CPM versions behind — causing the failing `unit-test` job.

## Changes
- `Aspire.Hosting` / `Aspire.Hosting.Testing` / `Aspire.MongoDB.Driver`: 13.3.5 → 13.4.2
- `Microsoft.Extensions.Configuration.Binder` / `Diagnostics.HealthChecks` / `Hosting` / `Hosting.Abstractions`: 10.0.7 → 10.0.8
- `MongoDB.Driver`: 3.6.0 → 3.8.1 (newly required by `Aspire.MongoDB.Driver` 13.4.2)
- `SharpCompress`: 0.48.0 → 1.0.0 (newly required by `Aspire.MongoDB.Driver` 13.4.2; newer than the 0.48.0 security pin from #44, so GHSA-6c8g-7p36-r338 stays fixed)

## Validation
- `dotnet restore`: clean (no NU1109/NU1902/NU1903)
- `dotnet build`: 0 warnings / 0 errors
- Unit tests: 201/201 pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>