### PR TITLE
Branding: use "Aspire" instead of ".NET Aspire"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/Aspire.Hosting.DocumentDB.svg)](https://www.nuget.org/packages/Aspire.Hosting.DocumentDB)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/integrations-overview) hosting integration for [DocumentDB](https://github.com/documentdb/documentdb), the open-source MongoDB-compatible document database built on PostgreSQL.
+A [Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/integrations-overview) hosting integration for [DocumentDB](https://github.com/documentdb/documentdb), the open-source MongoDB-compatible document database built on PostgreSQL.
 
 This package lets you add a DocumentDB container to your Aspire AppHost with a single line of code. Connection strings, credentials, TLS, and container lifecycle are managed automatically.
 
@@ -12,7 +12,7 @@ This package lets you add a DocumentDB container to your Aspire AppHost with a s
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download) or later
-- [.NET Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
+- [Aspire workload](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling): `dotnet workload install aspire`
 - [Docker](https://www.docker.com/products/docker-desktop/) (DocumentDB runs as a Linux container)
 
 ### Install the package

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,13 @@
 # Getting started
 
-This guide walks you through adding [DocumentDB](https://github.com/documentdb/documentdb) to a .NET Aspire application. By the end, you will have a running Aspire app with a DocumentDB container that your services can connect to using the MongoDB driver.
+This guide walks you through adding [DocumentDB](https://github.com/documentdb/documentdb) to an Aspire application. By the end, you will have a running Aspire app with a DocumentDB container that your services can connect to using the MongoDB driver.
 
 ## Prerequisites
 
 | Requirement | Details |
 |---|---|
 | .NET 10 SDK or later | [Download](https://dotnet.microsoft.com/download) |
-| .NET Aspire workload | `dotnet workload install aspire` |
+| Aspire workload | `dotnet workload install aspire` |
 | Docker | DocumentDB runs as a Linux container. [Docker Desktop](https://www.docker.com/products/docker-desktop/) or any Docker-compatible runtime works. |
 | IDE (optional) | Visual Studio 2022 17.9+, VS Code with C# Dev Kit, or JetBrains Rider |
 

--- a/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
+++ b/src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj
@@ -9,7 +9,7 @@
 
   <!-- NuGet package metadata -->
   <PropertyGroup>
-    <Description>DocumentDB support for .NET Aspire. Provides extension methods and resource definitions for a .NET Aspire AppHost to configure a DocumentDB resource.</Description>
+    <Description>DocumentDB support for Aspire. Provides extension methods and resource definitions for an Aspire AppHost to configure a DocumentDB resource.</Description>
     <Authors>Microsoft</Authors>
     <Copyright>Copyright (c) Microsoft 2025</Copyright>
     <PackageTags>aspire integration hosting documentdb mongodb cosmosdb azure database</PackageTags>

--- a/src/Aspire.Hosting.DocumentDB/README.md
+++ b/src/Aspire.Hosting.DocumentDB/README.md
@@ -1,6 +1,6 @@
 # Aspire.Hosting.DocumentDB
 
-[DocumentDB](https://github.com/documentdb/documentdb) is an open-source, MongoDB-compatible document database built on PostgreSQL. This package provides .NET Aspire hosting integration to configure and run a DocumentDB container as part of your distributed application.
+[DocumentDB](https://github.com/documentdb/documentdb) is an open-source, MongoDB-compatible document database built on PostgreSQL. This package provides Aspire hosting integration to configure and run a DocumentDB container as part of your distributed application.
 
 ## Getting started
 
@@ -142,4 +142,4 @@ builder.AddDocumentDB("documentdb")
 - [Changelog](https://github.com/microsoft/azure-databases-aspire/blob/main/CHANGELOG.md) — release history
 - [License](https://github.com/microsoft/azure-databases-aspire/blob/main/LICENSE) — package license
 - [DocumentDB project](https://github.com/documentdb/documentdb) — the database itself
-- [.NET Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) — Aspire framework docs
+- [Aspire documentation](https://learn.microsoft.com/en-us/dotnet/aspire/) — Aspire framework docs


### PR DESCRIPTION
## Use "Aspire" instead of ".NET Aspire"

Aspire was rebranded from **".NET Aspire"** to simply **"Aspire"**. This PR updates current references in this repository to the new name.

### What changed
- Replaced `.NET Aspire` → `Aspire` in prose/docs/samples.

### What was intentionally left unchanged
- Historical mentions (release notes, changelogs, and sentences explaining the former name).
- `ASP.NET`-adjacent text (the replacement is guarded so `ASP.NET Aspire` is not affected).

> Opened as a **draft** for maintainer review. Generated as part of a coordinated branding cleanup — happy to adjust scope or wording.
