### PR TITLE
Pin MessagePack transitive dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,8 +34,12 @@
     Snappier 1.3.1:
       * Clears GHSA-pggp-6c3x-2xmx (decompression infinite-loop DoS, high; affects
         <= 1.3.0).
+    MessagePack 3.1.7:
+      * Clears the vulnerable 2.5.192 version resolved transitively through Aspire
+        dependencies.
   -->
   <ItemGroup Label="Transitive pins">
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="SharpCompress" Version="1.0.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Pin transitive MessagePack dependency to 3.1.7
- Keep NuGet audit restore passing when warnings are treated as errors

## Validation
- dotnet restore azure-databases-aspire.sln --verbosity minimal
- dotnet build azure-databases-aspire.sln --no-restore --verbosity minimal
- dotnet test tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj --no-build --filter "Category=Unit" --verbosity minimal