### PR TITLE
Bump Microsoft.NET.Test.Sdk from 18.6.0 to 18.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="JsonSchema.Net" Version="7.3.3" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="9.0.0-beta.25204.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary
- Rebase the Microsoft.NET.Test.Sdk 18.7.0 bump from #90 onto latest main

## Validation
- dotnet restore azure-databases-aspire.sln --verbosity minimal
- dotnet build azure-databases-aspire.sln --no-restore --verbosity minimal
- dotnet test tests/Aspire.Hosting.DocumentDB.Tests/Aspire.Hosting.DocumentDB.Tests.csproj --no-build --filter "Category=Unit" --verbosity minimal

## Notes
Direct push to the Dependabot branch in microsoft/azure-databases-aspire using GuanzhouSong was denied with 403, so this PR replaces #90 from the personal fork.