### PR TITLE
Update workflow actions for Node 24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 

--- a/.github/workflows/check-documentdb-version.yml
+++ b/.github/workflows/check-documentdb-version.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -36,7 +36,7 @@ jobs:
         run: dotnet pack src/Aspire.Hosting.DocumentDB/Aspire.Hosting.DocumentDB.csproj -c Release --no-build -o ./artifacts
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nuget-package
           path: ./artifacts/*.nupkg


### PR DESCRIPTION
## Summary
- Update workflow JavaScript actions to Node 24-compatible majors:
  - `actions/setup-dotnet@v5`
  - `actions/setup-python@v6`
  - `actions/upload-artifact@v6`

## Validation
- Verified the referenced action metadata declares `runs.using: node24`
- Confirmed all repository workflows no longer reference the Node 20 majors that triggered the deprecation warnings
