### PR TITLE
Fix the data bind mount test that broke main on Linux CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: build-test-${{ github.event.pull_request.number || github.ref }}

--- a/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBFeatureMatrixEndToEndTests.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/DocumentDBFeatureMatrixEndToEndTests.cs
@@ -168,9 +168,11 @@ public class DocumentDBFeatureMatrixEndToEndTests
                 await app.StopAsync(cts.Token);
             }
 
-            // The PostgreSQL data directory must be visible on the host side of the mount.
+            // The PostgreSQL data directory must be visible on the host side of the mount. It is
+            // read back through a container because initdb leaves the directory 0700 owned by the
+            // container's uid, which locks this process out of the host path on Linux.
             Assert.True(
-                Directory.EnumerateFileSystemEntries(bindMountPath).Any(),
+                (await ListBindMountEntriesAsync(bindMountPath)).Length > 0,
                 $"Expected the DocumentDB data directory to be materialised under '{bindMountPath}'.");
 
             await using (var app = await BuildAndStartAsync(cts.Token))
@@ -189,6 +191,7 @@ public class DocumentDBFeatureMatrixEndToEndTests
         }
         finally
         {
+            await TryRelaxBindMountPermissionsAsync(bindMountPath);
             TryDeleteDirectory(bindMountPath);
         }
     }

--- a/tests/Aspire.Hosting.DocumentDB.Tests/Utils/DocumentDBEndToEndSupport.cs
+++ b/tests/Aspire.Hosting.DocumentDB.Tests/Utils/DocumentDBEndToEndSupport.cs
@@ -388,6 +388,58 @@ internal static class DocumentDBEndToEndSupport
         return output;
     }
 
+    /// <summary>
+    /// Runs a shell command as root against a host directory bind-mounted at <c>/probe</c>.
+    /// </summary>
+    /// <remarks>
+    /// The DocumentDB entrypoint runs <c>initdb</c> against <c>DATA_PATH</c>, which leaves the data
+    /// directory mode 0700 owned by the container's uid. Linux bind mounts share the host inode, so
+    /// once the container has started, a test process running under a different uid — which is the
+    /// case on CI runners — can no longer even enumerate the host path. Docker Desktop on Windows and
+    /// macOS hides that behind a filesystem translation layer, which is why host-side enumeration
+    /// only fails on Linux. Reading the mount back through a container behaves the same everywhere.
+    /// The curated DocumentDB image doubles as the probe so no additional image has to be pulled.
+    /// </remarks>
+    public static async Task<(int ExitCode, string StandardOutput)> RunInBindMountAsync(
+        string hostPath,
+        string shellCommand,
+        bool isReadOnly = true) =>
+        await RunDockerAsync(
+            "run", "--rm", "--user", "0:0", "--entrypoint", "/bin/sh",
+            "-v", isReadOnly ? $"{hostPath}:/probe:ro" : $"{hostPath}:/probe",
+            $"{DocumentDBContainerImageTags.Registry}/{DocumentDBContainerImageTags.Image}:{DocumentDBContainerImageTags.Tag}",
+            "-c", shellCommand);
+
+    /// <summary>Lists the entries of a bind-mounted host directory from inside a container.</summary>
+    public static async Task<string[]> ListBindMountEntriesAsync(string hostPath)
+    {
+        var (exitCode, output) = await RunInBindMountAsync(hostPath, "ls -A /probe");
+
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Could not list the bind-mounted host path '{hostPath}' from a container (exit code {exitCode}).");
+        }
+
+        return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>
+    /// Widens the modes under a bind-mounted host directory so the test process can delete it.
+    /// </summary>
+    /// <remarks>Best effort: a leaked temp directory is acceptable, a masked test failure is not.</remarks>
+    public static async Task TryRelaxBindMountPermissionsAsync(string hostPath)
+    {
+        try
+        {
+            await RunInBindMountAsync(hostPath, "chmod -R 0777 /probe", isReadOnly: false);
+        }
+        catch (InvalidOperationException)
+        {
+            // Docker is unavailable or wedged; the host-side delete will fall back to leaking.
+        }
+    }
+
     public static async Task RemoveVolumeAsync(string volumeName) =>
         await RunDockerAsync("volume", "rm", "-f", volumeName);
 


### PR DESCRIPTION
## Problem

[Build and Test run 30320682648](https://github.com/microsoft/azure-databases-aspire/actions/runs/30320682648) went red on `main`. The build itself was clean (`0 Error(s)`); the `integration-test` job failed on a single test added in #104:

```
Failed Aspire.Hosting.DocumentDB.Tests.DocumentDBFeatureMatrixEndToEndTests
      .DataBindMountWritesToTheHostPathAndSurvivesARestart [11 s]
  System.UnauthorizedAccessException : Access to the path
  '/tmp/aspire-documentdb-e2e/175739e0afa94d83b8b87a486a25e2c0' is denied.
  ---- System.IO.IOException : Permission denied
     at System.IO.Directory.InternalEnumeratePaths(...)
     at ...DataBindMountWritesToTheHostPathAndSurvivesARestart() in
       DocumentDBFeatureMatrixEndToEndTests.cs:line 172
```

## Root cause

`WithDataBindMount` mounts the host directory at `/data` and points `DATA_PATH` at it. The DocumentDB entrypoint then runs `initdb` there, which leaves the directory mode `0700` owned by the container's uid:

```
drwx------ 20 1000 1000  /host/d1
-rw-------  1 1000 1000  PG_VERSION
drwx------  5 1000 1000  base
...
```

Linux bind mounts share the host inode, so that ownership lands on the host path. The GitHub Actions `runner` user is uid 1001, so the assertion's host-side `Directory.EnumerateFileSystemEntries` gets `EACCES`. Reproduced exactly:

```
# as uid 1001, the CI runner user
ls: cannot open directory '/probe': Permission denied
```

Docker Desktop on Windows and macOS hides Linux ownership behind a filesystem translation layer, so the same test passes locally — which is why this landed green and broke `main`.

The `finally` block had the same problem in a quieter form: `Directory.Delete` threw `UnauthorizedAccessException`, which `TryDeleteDirectory` swallowed, so every Linux run leaked its temp directory.

## Fix

Read the mount back through a short-lived root container rather than from the host. Three helpers in `DocumentDBEndToEndSupport`:

- `RunInBindMountAsync` — runs a shell command as root against the host path bind-mounted at `/probe`. It reuses the curated DocumentDB image, which the scenario has already pulled, so no extra image or network round-trip is added to the job.
- `ListBindMountEntriesAsync` — the assertion path.
- `TryRelaxBindMountPermissionsAsync` — `chmod -R 0777` before cleanup so the temp directory is really deleted; best effort, so a wedged Docker daemon can't mask a test failure.

The test still makes exactly the same claim — the data directory materialises on the host side of the mount — it just reads it in a way that works on every host OS.

## Validation

- Reproduced the CI failure and verified the fix against a genuine `0700` uid-1000 directory inside the Docker Linux VM: uid 1001 → `Permission denied`; probe (`--user 0:0`, `:ro`) → lists `base`, `PG_VERSION`; cleanup `chmod` → `drwxrwxrwx`.
- Confirmed the probe works with a Windows host path through Docker Desktop.
- `dotnet build` — 0 warnings, 0 errors.
- `DocumentDBFeatureMatrixEndToEndTests` — 11/11 passed locally.
