### PR TITLE
Prepare changelog for v0.114.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-### Added
-- Pairing `WithPostgresVersion(DocumentDBPostgresVersion.Pg18)` with a DocumentDB version older than `0.114.0` now fails at startup with an actionable message naming the recovery, instead of failing the container pull with an opaque manifest-not-found error. Upstream only publishes `pg18-` images from `0.114.0` onwards, so every older pairing produces a well-formed tag that does not exist. Custom images and tags outside the `pg{NN}-X.Y.Z` grammar are exempt, and manifest generation is unaffected.
-
-### Fixed
-- Corrected the `UseTls` XML documentation (and the Markdown docs) that claimed the DocumentDB Local container *requires* TLS connections. From DocumentDB `0.114.0` the container's default `TLS_MODE=allowTLS` accepts both plain and TLS connections, so `UseTls(false)` now works against the default image; images up to `0.113.0` rejected plain connections regardless of that setting. Documented `.WithEnvironment("TLS_MODE", "requireTLS")` as the way to reject plain connections, including that it contradicts `UseTls(false)` and that the value is case-sensitive.
-- Corrected the data-persistence documentation, which recommended `WithDataVolume()` and `WithDataBindMount()` without pinning credentials — the one combination that breaks. The container hashes the configured password into a PostgreSQL role the first time it initialises a data directory, and that role is stored in the volume; because `AddDocumentDB` generates a random password when none is supplied, the *second* run presents a password the volume no longer recognises and every connection fails with `MongoAuthenticationException` / `Command saslContinue failed: Invalid key`, with the data intact but unreachable. `docs/configuration.md` now documents the caveat under both methods, and `docs/troubleshooting.md` carries a dedicated symptom entry with recovery paths (including `ALTER ROLE` through `WithPostgresEndpoint()`, so an existing volume need not be discarded).
-
 <!-- auto-generated:documentdb-versions-start -->
 _No upstream DocumentDB versions detected since the last release. This block is rewritten in place by `eng/scripts/check-documentdb-versions.py`; reset it to this line when cutting a release, after moving its contents into the dated section below._
 <!-- auto-generated:documentdb-versions-end -->
+
+## [0.114.1] - 2026-07-29
+
+### Fixed
+- Pairing `WithPostgresVersion(DocumentDBPostgresVersion.Pg18)` with a DocumentDB version older than `0.114.0` now fails at startup with an actionable message naming the recovery, instead of failing the container pull with an opaque manifest-not-found error. Upstream only publishes `pg18-` images from `0.114.0` onwards, so every older pairing produces a well-formed tag that does not exist. `Pg18` was introduced in `0.114.0`, so this gap shipped with that release. Custom images and tags outside the `pg{NN}-X.Y.Z` grammar are exempt, and manifest generation is unaffected.
+- Corrected the `UseTls` XML documentation (and the Markdown docs) that claimed the DocumentDB Local container *requires* TLS connections. From DocumentDB `0.114.0` the container's default `TLS_MODE=allowTLS` accepts both plain and TLS connections, so `UseTls(false)` now works against the default image; images up to `0.113.0` rejected plain connections regardless of that setting. Documented `.WithEnvironment("TLS_MODE", "requireTLS")` as the way to reject plain connections, including that it contradicts `UseTls(false)` and that the value is case-sensitive.
+- Corrected the data-persistence documentation, which recommended `WithDataVolume()` and `WithDataBindMount()` without pinning credentials — the one combination that breaks. The container hashes the configured password into a PostgreSQL role the first time it initialises a data directory, and that role is stored in the volume; because `AddDocumentDB` generates a random password when none is supplied, the *second* run presents a password the volume no longer recognises and every connection fails with `MongoAuthenticationException` / `Command saslContinue failed: Invalid key`, with the data intact but unreachable. `docs/configuration.md` now documents the caveat under both methods, and `docs/troubleshooting.md` carries a dedicated symptom entry with recovery paths (including `ALTER ROLE` through `WithPostgresEndpoint()`, so an existing volume need not be discarded).
 
 ## [0.114.0] - 2026-07-20
 
@@ -138,7 +138,8 @@ _No upstream DocumentDB versions detected since the last release. This block is 
 - SCRAM-SHA-256 authentication support
 - Container image: `ghcr.io/documentdb/documentdb/documentdb-local`
 
-[Unreleased]: https://github.com/microsoft/azure-databases-aspire/compare/v0.114.0...HEAD
+[Unreleased]: https://github.com/microsoft/azure-databases-aspire/compare/v0.114.1...HEAD
+[0.114.1]: https://github.com/microsoft/azure-databases-aspire/compare/v0.114.0...v0.114.1
 [0.114.0]: https://github.com/microsoft/azure-databases-aspire/compare/v0.113.0...v0.114.0
 [0.113.0]: https://github.com/microsoft/azure-databases-aspire/compare/v0.112.0...v0.113.0
 [0.112.0]: https://github.com/microsoft/azure-databases-aspire/compare/v0.111.0...v0.112.0


### PR DESCRIPTION
Cuts the entries accumulated in `[Unreleased]` since v0.114.0 into a dated `## [0.114.1] - 2026-07-29` section. Changelog only — no source changes.

## Why 0.114.1 and not 0.115.0

The minor version mirrors the upstream DocumentDB minor: 0.110 → 0.114 map 1:1, and each was cut when upstream shipped the matching release. Upstream's newest release is still `v0.114-0`, so there is no DocumentDB 0.115.0 to mirror. Spending 0.115.0 on a package-only fix would break that mapping and collide with `check-documentdb-versions.py` when DocumentDB 0.115.0 actually ships.

A patch is also the semantically correct bump: none of the three entries adds public API. The pg18 guard is entirely internal (`MinimumVersionByPgVariant`, `SubscribeMinimumPgVariantImageGuard`), and there is precedent in v0.109.2.

## Why not just wait

The two documentation corrections only reach consumers through a release — the XML doc comments ship in the assembly, and `docs/**/*.md`, `README.md` and `CHANGELOG.md` are packed into the nupkg. Upstream cadence is ~4-6 weeks, so waiting for a 0.115.0 that does not exist yet leaves the corrected TLS and data-persistence guidance unpublished while the incorrect guidance stays live on NuGet.

## Three details in this cut

**The pg18 guard moves from `Added` to `Fixed`.** It closes a gap introduced by 0.114.0 itself, which added `DocumentDBPostgresVersion.Pg18` while upstream only publishes `pg18-` images from 0.114.0 onwards — so older pairings resolve to a well-formed tag that does not exist and fail the pull with an opaque manifest-not-found error. This matches the v0.112.0 precedent, where the equivalent `WithPostgresEndpoint()` startup guard was filed under `Fixed`.

**`[Unreleased]` is re-added above the new section, not renamed,** and the auto-generated marker block moves up into it. Renaming without re-adding is precisely the failure `check-documentdb-versions.py` guards against — `warn_if_markers_outside_unreleased()` treats a missing heading as misplaced, so every scheduled run would warn and refuse to adopt new upstream versions until it was restored. The block body is already the documented reset line, so it moves as-is.

**Compare links** gain a `0.114.1` entry, and `[Unreleased]` now diffs from `v0.114.1`.

## Verification

- `check_changelog_placement()` reports the markers correctly placed (no warning).
- Replayed the release-notes extractor from `nuget-publish.yml` against the new file: it matches `## [0.114.1] - 2026-07-29`, stops at `## [0.114.0]`, and yields all three bullets rather than falling back to a bare `Release v0.114.1.`
- `python -m unittest discover -s eng/scripts/tests` — 49 passed.
- `dotnet build -c Release` on the package project — clean, 0 warnings.
- `dotnet pack` confirms MinVer currently computes `0.114.1-alpha.0.x`, so tagging `v0.114.1` yields exactly `0.114.1`.

## Not addressed here

`nuget-publish.yml` runs `dotnet test` unfiltered, so the ~20 container-backed E2E tests added in #103/#104/#106 now sit on the publish critical path. The latest `main` run finishes them in ~3.5 min, so this is not blocking, but it is worth deciding separately whether publish should filter to `Category=Unit`.

Tag deliberately not pushed — merge this first, then tag `v0.114.1` on the merge commit to trigger the publish workflow.
